### PR TITLE
Sync user repo / stars using RabbitMQ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,9 @@ install:
 
 before_script:
     - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-    - ./bin/console doctrine:database:create
-    - ./bin/console doctrine:schema:create
+    - ./bin/console doctrine:database:create --env=test
+    - ./bin/console doctrine:schema:create --env=test
+    - ./bin/console doctrine:fixtures:load --env=test -n
     - ./bin/rabbit vhost:mapping:create -p guest app/config/rabbit_vhost.yml
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+services:
+    - rabbitmq
+    - redis
+
 sudo: false
 
 cache:
@@ -23,6 +27,9 @@ install:
 
 before_script:
     - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    - ./bin/console doctrine:database:create
+    - ./bin/console doctrine:schema:create
+    - ./bin/rabbit vhost:mapping:create -p guest app/config/rabbit_vhost.yml
 
 script:
     - ./bin/simple-phpunit -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
         - php: nightly
 
 install:
-    - composer --prefer-dist install --no-interaction
+    - composer --prefer-dist install --no-interaction -o --no-progress
 
 before_script:
     - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -25,6 +25,7 @@ class AppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
+            $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
         }
 
         return $bundles;

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -16,6 +16,7 @@ class AppKernel extends Kernel
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new MarcW\RssWriter\Bundle\MarcWRssWriterBundle(),
             new KnpU\OAuth2ClientBundle\KnpUOAuth2ClientBundle(),
+            new Swarrot\SwarrotBundle\SwarrotBundle(),
             new AppBundle\AppBundle(),
         ];
 

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -19,7 +19,7 @@
     <div class="header">
         <div class="home-menu pure-menu pure-menu-horizontal pure-menu-fixed">
             <div class="middle-content">
-                <a class="pure-menu-heading" href="/">Bandito.re</a>
+                <a class="pure-menu-heading" href="{{ url('homepage') }}">Bandito.re</a>
 
                 <ul class="pure-menu-list">
                     <li class="pure-menu-item pure-menu-selected"><a href="https://github.com/j0k3r/banditore" class="pure-menu-link">View it on Github</a></li>
@@ -33,19 +33,6 @@
     </div>
 
     <div class="content-wrapper">
-        {% block splash %}
-            <div class="splash-container middle-content">
-                <div class="splash">
-                    <h1 class="splash-head">Get new release in your RSS!</h1>
-                    <p>We gather new releases from your starred Github repositories and generate a RSS feed with them.</p>
-                    <p>Just for you.</p>
-                    <p>
-                        <a href="{{ url('github_connect') }}" class="pure-button pure-button-primary">Try it!</a>
-                    </p>
-                </div>
-            </div>
-        {% endblock %}
-
         {% block body %}{% endblock %}
 
         <div class="footer l-box is-center">

--- a/app/Resources/views/default/dashboard.html.twig
+++ b/app/Resources/views/default/dashboard.html.twig
@@ -1,0 +1,38 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+<div class="content">
+    <div class="middle-content">
+        <h2 class="content-head is-center">Your starred repos</h2>
+
+        <table class="pure-table">
+            <thead>
+                <tr>
+                    <th>Repository</th>
+                    <th>Last version</th>
+                    <th>Published at</th>
+                </tr>
+            </thead>
+
+            <tbody>
+                {% for repo in repos -%}
+                    <tr{% if loop.index is odd %} class="pure-table-odd"{% endif %}>
+                        <td>
+                            <img class="repo-avatar" src="{{ repo.ownerAvatar }}&amp;size=20"/>
+                            <a href="https://github.com/{{ repo.fullName }}">{{ repo.fullName }}</a>
+                        </td>
+                        <td>
+                            {%- if repo.name -%}
+                                {{ repo.name }} (<a href="{{ repo|link_to_version }}">{{ repo.tagName }}</a>)
+                            {%- else -%}
+                                <a href="{{ repo|link_to_version }}">{{ repo.tagName }}</a>
+                            {%- endif -%}
+                        </td>
+                        <td><time datetime="{{ repo.createdAt|date("c") }}" title="{{ repo.createdAt|date("c") }}">{{ repo.createdAt|time_diff }}</time></td>
+                    </tr>
+                {% endfor -%}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -1,6 +1,17 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
+<div class="splash-container middle-content">
+    <div class="splash">
+        <h1 class="splash-head">Get new release in your RSS!</h1>
+        <p>We gather new releases from your starred Github repositories and generate a RSS feed with them.</p>
+        <p>Just for you.</p>
+        <p>
+            <a href="{{ url('github_connect') }}" class="pure-button pure-button-primary">Try it!</a>
+        </p>
+    </div>
+</div>
+
 <div class="content">
     <div class="middle-content">
         <h2 class="content-head is-center">What Banditore can do for me?</h2>

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -66,3 +66,26 @@ knpu_oauth2_client:
             # a route name you'll create
             redirect_route: github_callback
             redirect_params: {}
+
+swarrot:
+    provider: amqp_lib # pecl or amqp_lib
+    connections:
+        rabbitmq:
+            host: '%rabbitmq_host%'
+            port: '%rabbitmq_port%'
+            login: '%rabbitmq_login%'
+            password: '%rabbitmq_password%'
+            vhost: '/'
+    consumers:
+        banditore.sync_user_repo:
+            processor: banditore.consumer.sync_user_repo
+            extras:
+                poll_interval: 500000
+                requeue_on_error: false
+            middleware_stack:
+                - configurator: swarrot.processor.exception_catcher
+                - configurator: swarrot.processor.ack
+    messages_types:
+        banditore.sync_user_repo.publisher:
+            connection: rabbitmq
+            exchange: banditore.sync_user_repo

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -49,6 +49,7 @@ doctrine:
         user: "%database_user%"
         password: "%database_password%"
         charset: utf8mb4
+        server_version: 5.6
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -25,6 +25,7 @@ framework:
     trusted_hosts: ~
     trusted_proxies: ~
     session:
+        name: banditore
         # http://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         handler_id: session.handler.native_file
         save_path: "%kernel.root_dir%/../var/sessions/%kernel.environment%"

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -8,6 +8,17 @@ framework:
     profiler:
         collect: false
 
+doctrine:
+    dbal:
+        driver: pdo_mysql
+        host: "127.0.0.1"
+        port: ~
+        dbname: "banditore_test"
+        user: "root"
+        password: ~
+        charset: utf8mb4
+        server_version: 5.6
+
 web_profiler:
     toolbar: false
     intercept_redirects: false

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -11,3 +11,6 @@ framework:
 web_profiler:
     toolbar: false
     intercept_redirects: false
+
+parameters:
+    swarrot.publisher.class: Swarrot\SwarrotBundle\Broker\BlackholePublisher

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,7 +1,7 @@
 parameters:
     database_host: 127.0.0.1
     database_port: ~
-    database_name: symfony
+    database_name: banditore
     database_user: root
     database_password: ~
 
@@ -14,5 +14,12 @@ parameters:
     redis_port: 6379
     redis_database: 2
 
+    # used to generate url from the backend
     project_host: banditore.com
     project_scheme: http
+
+    # rabbit
+    rabbitmq_host: 127.0.0.1
+    rabbitmq_port: 5672
+    rabbitmq_login: 'guest'
+    rabbitmq_password: 'guest'

--- a/app/config/rabbit_vhost.yml
+++ b/app/config/rabbit_vhost.yml
@@ -1,0 +1,17 @@
+'/':
+    parameters:
+        # If true, all queues will have a dl and the corresponding mapping with the exchange "dl"
+        with_dl: false
+        # If true, all exchange will be declared with an unroutable config
+        with_unroutable: false
+
+    exchanges:
+        banditore.sync_user_repo:
+            type: direct
+            durable: true
+
+    queues:
+        banditore.sync_user_repo:
+            durable: true
+            bindings:
+                - exchange: banditore.sync_user_repo

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -4,7 +4,11 @@ services:
 
     banditore.github.authenticator:
         class: AppBundle\Security\GithubAuthenticator
-        autowire: true
+        arguments:
+            - "@knpu.oauth2.registry"
+            - "@doctrine.orm.default_entity_manager"
+            - "@router"
+            - "@swarrot.publisher"
 
     banditore.client.redis:
         class: Redis
@@ -68,3 +72,13 @@ services:
             - "@banditore.repository.user"
             - "%project_host%"
             - "%project_scheme%"
+
+    # consumers
+    banditore.consumer.sync_user_repo:
+        class: AppBundle\Consumer\SyncUserRepo
+        arguments:
+            - "@doctrine.orm.default_entity_manager"
+            - "@banditore.repository.user"
+            - "@banditore.repository.star"
+            - "@banditore.repository.repo"
+            - "@logger"

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -82,3 +82,15 @@ services:
             - "@banditore.repository.star"
             - "@banditore.repository.repo"
             - "@logger"
+
+    # twig extensions
+    banditore.twig_extension.repo_version:
+        class: AppBundle\Twig\RepoVersionExtension
+        public: false
+        tags:
+            - { name: twig.extension }
+
+    twig.extension.date:
+        class: Twig_Extensions_Extension_Date
+        tags:
+            - { name: twig.extension }

--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,14 @@
         "cache/redis-adapter": "^0.4.2",
         "odolbeau/rabbit-mq-admin-toolkit": "^3.2",
         "swarrot/swarrot-bundle": "^1.4",
-        "php-amqplib/php-amqplib": "^2.6"
+        "php-amqplib/php-amqplib": "^2.6",
+        "twig/extensions": "^1.4"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.0",
         "sensio/generator-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^3.0"
+        "symfony/phpunit-bridge": "^3.0",
+        "doctrine/doctrine-fixtures-bundle": "^2.3"
     },
     "scripts": {
         "symfony-scripts": [

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,10 @@
         "php-http/guzzle6-adapter": "^1.1",
         "knpuniversity/oauth2-client-bundle": "^1.9",
         "ramsey/uuid": "^3.5",
-        "cache/redis-adapter": "^0.4.2"
+        "cache/redis-adapter": "^0.4.2",
+        "odolbeau/rabbit-mq-admin-toolkit": "^3.2",
+        "swarrot/swarrot-bundle": "^1.4",
+        "php-amqplib/php-amqplib": "^2.6"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.0",
@@ -57,6 +60,9 @@
         ]
     },
     "config": {
+        "platform": {
+            "php": "5.6.30"
+        },
         "bin-dir": "bin"
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "60a596b005a76b9620e644c7d419a880",
+    "content-hash": "25402f6f0a58157698d7d9f42eb3f6ac",
     "packages": [
         {
             "name": "cache/adapter-common",
@@ -3392,6 +3392,58 @@
             "time": "2017-02-17T00:00:43+00:00"
         },
         {
+            "name": "twig/extensions",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig-extensions.git",
+                "reference": "f0bb8431c8691f5a39f1017d9a5967a082bf01ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig-extensions/zipball/f0bb8431c8691f5a39f1017d9a5967a082bf01ff",
+                "reference": "f0bb8431c8691f5a39f1017d9a5967a082bf01ff",
+                "shasum": ""
+            },
+            "require": {
+                "twig/twig": "~1.20|~2.0"
+            },
+            "require-dev": {
+                "symfony/translation": "~2.3"
+            },
+            "suggest": {
+                "symfony/translation": "Allow the time_diff output to be translated"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Twig_Extensions_": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Common additional features for Twig that do not directly belong in core",
+            "homepage": "http://twig.sensiolabs.org/doc/extensions/index.html",
+            "keywords": [
+                "i18n",
+                "text"
+            ],
+            "time": "2016-10-25T17:34:14+00:00"
+        },
+        {
             "name": "twig/twig",
             "version": "v1.31.0",
             "source": {
@@ -3454,6 +3506,122 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "doctrine/data-fixtures",
+            "version": "v1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/data-fixtures.git",
+                "reference": "17fa5bfe6ff52e35cb3d9ec37c934a2f4bd1fa2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/17fa5bfe6ff52e35cb3d9ec37c934a2f4bd1fa2e",
+                "reference": "17fa5bfe6ff52e35cb3d9ec37c934a2f4bd1fa2e",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "~2.2",
+                "php": "^5.6 || ^7.0"
+            },
+            "conflict": {
+                "doctrine/orm": "< 2.4"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.5.4",
+                "doctrine/orm": "^2.5.4",
+                "phpunit/phpunit": "^5.4.6"
+            },
+            "suggest": {
+                "doctrine/mongodb-odm": "For loading MongoDB ODM fixtures",
+                "doctrine/orm": "For loading ORM fixtures",
+                "doctrine/phpcr-odm": "For loading PHPCR ODM fixtures"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\DataFixtures": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Data Fixtures for all Doctrine Object Managers",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database"
+            ],
+            "time": "2016-09-20T10:07:57+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-fixtures-bundle",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineFixturesBundle.git",
+                "reference": "0f1a2f91b349e10f5c343f75ab71d23aace5b029"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineFixturesBundle/zipball/0f1a2f91b349e10f5c343f75ab71d23aace5b029",
+                "reference": "0f1a2f91b349e10f5c343f75ab71d23aace5b029",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/data-fixtures": "~1.0",
+                "doctrine/doctrine-bundle": "~1.0",
+                "php": ">=5.3.2",
+                "symfony/doctrine-bridge": "~2.3|~3.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\FixturesBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "http://www.doctrine-project.org"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Symfony DoctrineFixturesBundle",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "Fixture",
+                "persistence"
+            ],
+            "time": "2015-11-04T21:23:23+00:00"
+        },
         {
             "name": "friendsofphp/php-cs-fixer",
             "version": "v2.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "be176c15f0ec7bb3ddd1a581d127af7a",
+    "content-hash": "60a596b005a76b9620e644c7d419a880",
     "packages": [
         {
             "name": "cache/adapter-common",
@@ -1708,6 +1708,57 @@
             "time": "2016-11-26T00:15:39+00:00"
         },
         {
+            "name": "odolbeau/rabbit-mq-admin-toolkit",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/odolbeau/rabbit-mq-admin-toolkit.git",
+                "reference": "ebb2416e64d448a47d43b3d9f1046b3d13e40702"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/odolbeau/rabbit-mq-admin-toolkit/zipball/ebb2416e64d448a47d43b3d9f1046b3d13e40702",
+                "reference": "ebb2416e64d448a47d43b3d9f1046b3d13e40702",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "swarrot/swarrot": "~2.0",
+                "symfony/console": "^2.7|^3.0",
+                "symfony/yaml": "^2.4|^3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~1.12",
+                "phpunit/phpunit": ">=4.8"
+            },
+            "bin": [
+                "rabbit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Bab\\RabbitMq": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "RabbitMQ administration toolkit",
+            "keywords": [
+                "AMQP",
+                "admin",
+                "rabbitmq",
+                "toolkit"
+            ],
+            "time": "2016-11-15T16:29:18+00:00"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v2.0.4",
             "source": {
@@ -1754,6 +1805,76 @@
                 "random"
             ],
             "time": "2016-11-07T23:38:38+00:00"
+        },
+        {
+            "name": "php-amqplib/php-amqplib",
+            "version": "v2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-amqplib/php-amqplib.git",
+                "reference": "fa2f0d4410a11008cb36b379177291be7ee9e4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/fa2f0d4410a11008cb36b379177291be7ee9e4f6",
+                "reference": "fa2f0d4410a11008cb36b379177291be7ee9e4f6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.3.0"
+            },
+            "replace": {
+                "videlalvaro/php-amqplib": "self.version"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8",
+                "scrutinizer/ocular": "^1.1",
+                "squizlabs/php_codesniffer": "^2.5"
+            },
+            "suggest": {
+                "ext-sockets": "Use AMQPSocketConnection"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpAmqpLib\\": "PhpAmqpLib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Alvaro Videla",
+                    "role": "Original Maintainer"
+                },
+                {
+                    "name": "John Kelly",
+                    "email": "johnmkelly86@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Raúl Araya",
+                    "email": "nubeiro@gmail.com",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Formerly videlalvaro/php-amqplib.  This library is a pure PHP implementation of the AMQP protocol. It's been tested against RabbitMQ.",
+            "homepage": "https://github.com/php-amqplib/php-amqplib/",
+            "keywords": [
+                "message",
+                "queue",
+                "rabbitmq"
+            ],
+            "time": "2016-04-11T14:30:01+00:00"
         },
         {
             "name": "php-http/cache-plugin",
@@ -2611,6 +2732,126 @@
             "time": "2016-09-23T18:09:57+00:00"
         },
         {
+            "name": "swarrot/swarrot",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swarrot/swarrot.git",
+                "reference": "52d0ef764fdd0dc934cab1077822b6c3f08d8051"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swarrot/swarrot/zipball/52d0ef764fdd0dc934cab1077822b6c3f08d8051",
+                "reference": "52d0ef764fdd0dc934cab1077822b6c3f08d8051",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0",
+                "psr/log": "^1.0",
+                "symfony/options-resolver": "^2.3 || ^3.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.8",
+                "doctrine/common": "^2.3",
+                "doctrine/dbal": "^2.2",
+                "php-amqplib/php-amqplib": "^2.1",
+                "phpunit/phpunit": "^4.8.27 || ^5.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "^2.8",
+                "pecl-amqp": "*",
+                "php-amqplib/php-amqplib": "^2.1",
+                "symfony/console": "^2.4 || ^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Swarrot\\": "src/Swarrot"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Dolbeau",
+                    "homepage": "http://odolbeau.fr/"
+                }
+            ],
+            "description": "A simple lib to consume RabbitMQ queues",
+            "keywords": [
+                "AMQP",
+                "queue",
+                "swarrot",
+                "worker"
+            ],
+            "time": "2016-12-28T14:53:53+00:00"
+        },
+        {
+            "name": "swarrot/swarrot-bundle",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swarrot/SwarrotBundle.git",
+                "reference": "ab3021ab8e61c6a74771e6ad79c323981a632bec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swarrot/SwarrotBundle/zipball/ab3021ab8e61c6a74771e6ad79c323981a632bec",
+                "reference": "ab3021ab8e61c6a74771e6ad79c323981a632bec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "psr/log": "~1.0",
+                "swarrot/swarrot": "^2.1.1",
+                "symfony/console": "~2.4|~3.0",
+                "symfony/framework-bundle": "~2.4|~3.0"
+            },
+            "require-dev": {
+                "doctrine/common": "~2.2",
+                "doctrine/dbal": "~2.2",
+                "phpunit/phpunit": "~4.5",
+                "symfony/phpunit-bridge": "~2.8|~3.0"
+            },
+            "suggest": {
+                "php-amqplib/php-amqplib": "Required if using amqp_lib"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Swarrot\\SwarrotBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Dolbeau",
+                    "homepage": "http://odolbeau.fr/"
+                }
+            ],
+            "description": "SwarrotBundle",
+            "keywords": [
+                "bundle",
+                "swarrot"
+            ],
+            "time": "2016-07-19T09:36:09+00:00"
+        },
+        {
             "name": "symfony/monolog-bundle",
             "version": "v3.0.3",
             "source": {
@@ -3009,16 +3250,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.2.3",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "6306409b3836ed2936c7b0454f00711d0128748c"
+                "reference": "141569be5b33a7cf0d141fb88422649fe11b0c47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/6306409b3836ed2936c7b0454f00711d0128748c",
-                "reference": "6306409b3836ed2936c7b0454f00711d0128748c",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/141569be5b33a7cf0d141fb88422649fe11b0c47",
+                "reference": "141569be5b33a7cf0d141fb88422649fe11b0c47",
                 "shasum": ""
             },
             "require": {
@@ -3148,7 +3389,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-02-06T13:15:43+00:00"
+            "time": "2017-02-17T00:00:43+00:00"
         },
         {
             "name": "twig/twig",
@@ -3422,7 +3663,7 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.2.3",
+            "version": "v3.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
@@ -3602,5 +3843,8 @@
     "platform": {
         "php": ">=5.5.9"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.6.30"
+    }
 }

--- a/data/supervisor.conf
+++ b/data/supervisor.conf
@@ -1,0 +1,22 @@
+[group:sync_repo]
+programs=sync_repo_1,sync_repo_2
+
+[program:sync_repo_1]
+directory=/path/to/banditore
+command=/usr/bin/php bin/console swarrot:consume:banditore.sync_user_repo -e prod
+autostart=true
+autorestart=true
+stderr_logfile=/space/logs/supervisord/sync_user_repo_1.err
+stdout_logfile=/space/logs/supervisord/sync_user_repo_1.log
+user=deploy
+environment = http_proxy="",https_proxy=""
+
+[program:sync_repo_2]
+directory=/path/to/banditore
+command=/usr/bin/php bin/console swarrot:consume:banditore.sync_user_repo -e prod
+autostart=true
+autorestart=true
+stderr_logfile=/space/logs/supervisord/sync_user_repo_2.err
+stdout_logfile=/space/logs/supervisord/sync_user_repo_2.log
+user=deploy
+environment = http_proxy="",https_proxy=""

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,9 +22,8 @@
         <whitelist>
             <directory>src</directory>
             <exclude>
-                <directory>src/*Bundle/Resources</directory>
-                <directory>src/*/*Bundle/Resources</directory>
-                <directory>src/*/Bundle/*Bundle/Resources</directory>
+                <directory>src/AppBundle/Resources</directory>
+                <directory>src/AppBundle/DataFixtures</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/AppBundle/Command/CheckNewVersionCommand.php
+++ b/src/AppBundle/Command/CheckNewVersionCommand.php
@@ -124,6 +124,11 @@ class CheckNewVersionCommand extends ContainerAwareCommand
                 // using that way we retrieve all tags
                 $tags = $this->github->api('git')->tags()->all($username, $repoName);
             } catch (RuntimeException $e) {
+                if ($e->getCode() === 404) {
+                    $output->writeln('0 <comment>(No tags / releases)</comment>');
+                    continue;
+                }
+
                 $output->writeln('<error>' . $e->getMessage() . '</error>');
                 continue;
             }

--- a/src/AppBundle/Consumer/SyncUserRepo.php
+++ b/src/AppBundle/Consumer/SyncUserRepo.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace AppBundle\Consumer;
+
+use AppBundle\Entity\Repo;
+use AppBundle\Entity\Star;
+use AppBundle\Entity\User;
+use AppBundle\Repository\RepoRepository;
+use AppBundle\Repository\StarRepository;
+use AppBundle\Repository\UserRepository;
+use Doctrine\ORM\EntityManager;
+use Github\Client;
+use Psr\Log\LoggerInterface;
+use Swarrot\Broker\Message;
+use Swarrot\Processor\ProcessorInterface;
+
+/**
+ * Consumer message to sync user repo (usually happen after a successful login).
+ */
+class SyncUserRepo implements ProcessorInterface
+{
+    private $logger;
+    private $em;
+    private $userRepository;
+    private $starRepository;
+    private $repoRepository;
+
+    public function __construct(EntityManager $em, UserRepository $userRepository, StarRepository $starRepository, RepoRepository $repoRepository, LoggerInterface $logger)
+    {
+        $this->em = $em;
+        $this->userRepository = $userRepository;
+        $this->starRepository = $starRepository;
+        $this->repoRepository = $repoRepository;
+        $this->logger = $logger;
+    }
+
+    public function process(Message $message, array $options)
+    {
+        $data = json_decode($message->getBody(), true);
+
+        $user = $this->userRepository->find($data['user_id']);
+
+        if (null === $user) {
+            $this->logger->error('Can not find user', ['user' => $data['user_id']]);
+
+            return;
+        }
+
+        $this->logger->notice('Consume banditore.sync_user_repo message', ['user' => $user->getUsername()]);
+
+        $client = new Client();
+        $client->authenticate($user->getAccessToken(), null, Client::AUTH_HTTP_TOKEN);
+
+        try {
+            $nbRepos = $this->doSyncRepo($client, $user);
+        } catch (\Exception $e) {
+            $this->logger->error('Error while sending data to user', ['exception' => $e->getMessage(), 'user' => $user->getUsername()]);
+
+            return;
+        }
+
+        $this->logger->notice('Synced repos: ' . $nbRepos, ['user' => $user->getUsername()]);
+    }
+
+    /**
+     * Do the job to sync repo & star of a user.
+     *
+     * @param Client $client Github client
+     * @param User   $user   User to work on
+     */
+    private function doSyncRepo(Client $client, User $user)
+    {
+        $newStars = [];
+        $page = 1;
+        $perPage = 100;
+        $starredRepos = $client->api('current_user')->starring()->all($page, $perPage);
+
+        do {
+            $rateLimit = $client->api('rate_limit')->getRateLimits();
+            $this->logger->info('    sync ' . count($starredRepos) . ' starred repos', [
+                'user' => $user->getUsername(),
+                'rate' => $rateLimit['resources']['core']['remaining'],
+            ]);
+
+            foreach ($starredRepos as $starredRepo) {
+                $newStars[] = $starredRepo['full_name'];
+
+                $repo = $this->repoRepository->find($starredRepo['id']);
+
+                if (null === $repo) {
+                    $repo = new Repo();
+                    $repo->hydrateFromGithub($starredRepo);
+
+                    $this->em->persist($repo);
+                }
+
+                $star = $this->starRepository->findOneBy([
+                    'repo' => $starredRepo['id'],
+                    'user' => $user,
+                ]);
+
+                if (null === $star) {
+                    $star = new Star($user, $repo);
+
+                    $this->em->persist($star);
+                }
+
+                $this->em->flush();
+            }
+
+            $starredRepos = $client->api('current_user')->starring()->all($page++, $perPage);
+        } while (!empty($starredRepos));
+
+        // now remove unstarred repos
+        $this->doCleanOldStar($user, $newStars);
+
+        return count($newStars);
+    }
+
+    /**
+     * Clean old star.
+     * When user unstar a repo we also need to remove that association.
+     *
+     * @param User  $user
+     * @param array $newStars Current stars of the user
+     *
+     * @return mixed
+     */
+    private function doCleanOldStar(User $user, array $newStars)
+    {
+        $currentStars = $this->starRepository->findAllByUser($user->getId());
+
+        $starsToRemove = array_diff($currentStars, $newStars);
+
+        if (empty($starsToRemove)) {
+            return;
+        }
+
+        $starIds = [];
+        foreach ($starsToRemove as $starToRemove) {
+            $starIds[] = $this->repoRepository->findOneBy(['fullName' => $starsToRemove])->getId();
+        }
+
+        $this->logger->notice('Removed stars: ' . count($starIds), ['user' => $user->getUsername()]);
+
+        return $this->starRepository->removeFromUser($starIds, $user->getId());
+    }
+}

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Controller;
 
-use AppBundle\Entity\Repo;
 use AppBundle\Entity\User;
 use AppBundle\Webfeeds\Webfeeds;
 use MarcW\RssWriter\Bridge\Symfony\HttpFoundation\RssStreamedResponse;

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -22,11 +22,29 @@ class DefaultController extends Controller
      */
     public function indexAction(Request $request)
     {
+        if ($this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {
+            return $this->redirect($this->generateUrl('dashboard'));
+        }
+
+        return $this->render('default/index.html.twig');
+    }
+
+    /**
+     * @Route("/dashboard", name="dashboard")
+     */
+    public function dashboardAction(Request $request)
+    {
+        if (!$this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {
+            return $this->redirect($this->generateUrl('homepage'));
+        }
+
         if ($request->query->has('sync')) {
             // display message about sync in progress
         }
 
-        return $this->render('default/index.html.twig');
+        return $this->render('default/dashboard.html.twig', [
+            'repos' => $this->get('banditore.repository.version')->findLastVersionForEachRepoForUser($this->getUser()->getId()),
+        ]);
     }
 
     /**

--- a/src/AppBundle/DataFixtures/ORM/LoadRepoData.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadRepoData.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace AppBundle\DataFixtures\ORM;
+
+use AppBundle\Entity\Repo;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class LoadRepoData extends AbstractFixture implements OrderedFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        $repo1 = new Repo();
+        $repo1->hydrateFromGithub([
+            'id' => 666,
+            'name' => 'test',
+            'full_name' => 'test/test',
+            'description' => 'This is a test repo',
+            'owner' => [
+                'avatar_url' => 'http://0.0.0.0/test.jpg',
+            ],
+        ]);
+
+        $manager->persist($repo1);
+        $manager->flush();
+
+        $this->addReference('repo1', $repo1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrder()
+    {
+        return 20;
+    }
+}

--- a/src/AppBundle/DataFixtures/ORM/LoadRepoData.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadRepoData.php
@@ -21,11 +21,24 @@ class LoadRepoData extends AbstractFixture implements OrderedFixtureInterface
                 'avatar_url' => 'http://0.0.0.0/test.jpg',
             ],
         ]);
-
         $manager->persist($repo1);
+
+        $repo2 = new Repo();
+        $repo2->hydrateFromGithub([
+            'id' => 555,
+            'name' => 'symfony',
+            'full_name' => 'symfony/symfony',
+            'description' => 'The Symfony PHP framework',
+            'owner' => [
+                'avatar_url' => 'https://avatars2.githubusercontent.com/u/143937?v=3',
+            ],
+        ]);
+        $manager->persist($repo2);
+
         $manager->flush();
 
         $this->addReference('repo1', $repo1);
+        $this->addReference('repo2', $repo2);
     }
 
     /**

--- a/src/AppBundle/DataFixtures/ORM/LoadStarData.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadStarData.php
@@ -12,11 +12,14 @@ class LoadStarData extends AbstractFixture implements OrderedFixtureInterface
     public function load(ObjectManager $manager)
     {
         $star1 = new Star($this->getReference('user1'), $this->getReference('repo1'));
+        $star2 = new Star($this->getReference('user1'), $this->getReference('repo2'));
 
         $manager->persist($star1);
+        $manager->persist($star2);
         $manager->flush();
 
         $this->addReference('star1', $star1);
+        $this->addReference('star2', $star2);
     }
 
     /**

--- a/src/AppBundle/DataFixtures/ORM/LoadStarData.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadStarData.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AppBundle\DataFixtures\ORM;
+
+use AppBundle\Entity\Star;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class LoadStarData extends AbstractFixture implements OrderedFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        $star1 = new Star($this->getReference('user1'), $this->getReference('repo1'));
+
+        $manager->persist($star1);
+        $manager->flush();
+
+        $this->addReference('star1', $star1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrder()
+    {
+        return 30;
+    }
+}

--- a/src/AppBundle/DataFixtures/ORM/LoadUserData.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadUserData.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AppBundle\DataFixtures\ORM;
+
+use AppBundle\Entity\User;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class LoadUserData extends AbstractFixture implements OrderedFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        $user1 = new User();
+        $user1->setId(123);
+        $user1->setUsername('admin');
+        $user1->setName('Bob');
+        $user1->setAccessToken('1234567890');
+        $user1->setAvatar('http://0.0.0.0/avatar.jpg');
+
+        $manager->persist($user1);
+        $manager->flush();
+
+        $this->addReference('user1', $user1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrder()
+    {
+        return 10;
+    }
+}

--- a/src/AppBundle/DataFixtures/ORM/LoadVersionData.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadVersionData.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace AppBundle\DataFixtures\ORM;
+
+use AppBundle\Entity\Version;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class LoadVersionData extends AbstractFixture implements OrderedFixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        $version1 = new Version($this->getReference('repo1'));
+        $version1->hydrateFromGithub([
+            'tag_name' => 'v1.0.0',
+            'name' => 'First release',
+            'prerelease' => false,
+            'message' => 'YAY',
+            'published_at' => '19 february 2017',
+        ]);
+
+        $manager->persist($version1);
+        $manager->flush();
+
+        $this->addReference('version1', $version1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrder()
+    {
+        return 40;
+    }
+}

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -316,7 +316,7 @@ class User implements UserInterface
     /**
      * Set accessToken.
      *
-     * @param \DateTime $accessToken
+     * @param string $accessToken
      *
      * @return User
      */

--- a/src/AppBundle/Repository/StarRepository.php
+++ b/src/AppBundle/Repository/StarRepository.php
@@ -47,6 +47,7 @@ class StarRepository extends \Doctrine\ORM\EntityRepository
         return $this->createQueryBuilder('s')
             ->delete()
             ->where('s.repo IN (:ids)')->setParameter('ids', $starIds)
+            ->andWhere('s.repo = :userId')->setParameter('userId', $userId)
             ->getQuery()
             ->execute();
     }

--- a/src/AppBundle/Repository/StarRepository.php
+++ b/src/AppBundle/Repository/StarRepository.php
@@ -10,4 +10,44 @@ namespace AppBundle\Repository;
  */
 class StarRepository extends \Doctrine\ORM\EntityRepository
 {
+    /**
+     * Retrieve all repos starred by a user.
+     *
+     * @param int $userId User id
+     *
+     * @return array
+     */
+    public function findAllByUser($userId)
+    {
+        $repos = $this->createQueryBuilder('s')
+            ->select('r.fullName')
+            ->leftJoin('s.repo', 'r')
+            ->where('s.user = ' . $userId)
+            ->getQuery()
+            ->getArrayResult();
+
+        $res = [];
+        foreach ($repos as $repo) {
+            $res[] = $repo['fullName'];
+        }
+
+        return $res;
+    }
+
+    /**
+     * Remove stars for a user.
+     *
+     * @param array $starIds
+     * @param int   $userId
+     *
+     * @return mixed
+     */
+    public function removeFromUser($starIds, $userId)
+    {
+        return $this->createQueryBuilder('s')
+            ->delete()
+            ->where('s.repo IN (:ids)')->setParameter('ids', $starIds)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/src/AppBundle/Repository/StarRepository.php
+++ b/src/AppBundle/Repository/StarRepository.php
@@ -42,12 +42,12 @@ class StarRepository extends \Doctrine\ORM\EntityRepository
      *
      * @return mixed
      */
-    public function removeFromUser($starIds, $userId)
+    public function removeFromUser(array $starIds, $userId)
     {
         return $this->createQueryBuilder('s')
             ->delete()
             ->where('s.repo IN (:ids)')->setParameter('ids', $starIds)
-            ->andWhere('s.repo = :userId')->setParameter('userId', $userId)
+            ->andWhere('s.user = :userId')->setParameter('userId', $userId)
             ->getQuery()
             ->execute();
     }

--- a/src/AppBundle/Repository/UserRepository.php
+++ b/src/AppBundle/Repository/UserRepository.php
@@ -22,7 +22,7 @@ class UserRepository extends \Doctrine\ORM\EntityRepository
         return $this->createQueryBuilder('u')
             ->select('DISTINCT u.uuid')
             ->leftJoin('u.stars', 's')
-            ->andWhere('s.repo IN (:ids)')->setParameter('ids', $repoIds)
+            ->where('s.repo IN (:ids)')->setParameter('ids', $repoIds)
             ->getQuery()
             ->getArrayResult();
     }

--- a/src/AppBundle/Repository/VersionRepository.php
+++ b/src/AppBundle/Repository/VersionRepository.php
@@ -25,11 +25,36 @@ class VersionRepository extends \Doctrine\ORM\EntityRepository
             ->leftJoin('v.repo', 'r')
             ->leftJoin('r.stars', 's')
             ->leftJoin('s.user', 'u')
-            ->where('s.user = ' . $userId)
+            ->where('s.user = :userId')->setParameter('userId', $userId)
             ->andWhere('v.createdAt >= u.createdAt')
             ->orderBy('v.createdAt', 'desc')
             ->setMaxResults(10)
             ->getQuery()
             ->getArrayResult();
+    }
+
+    /**
+     * DQL query to retrieve last version of each repo starred by a user.
+     * We use DQL because it was to complex to use a query builder.
+     *
+     * @param  int $userId User ID
+     *
+     * @return array
+     */
+    public function findLastVersionForEachRepoForUser($userId)
+    {
+        $query = $this->getEntityManager()->createQuery("
+            SELECT v1.tagName, v1.name, v1.createdAt, r.fullName, r.ownerAvatar
+            FROM AppBundle\Entity\Version v1
+            LEFT JOIN AppBundle\Entity\Version v2 WITH ( v1.repo = v2.repo AND v1.createdAt < v2.createdAt )
+            LEFT JOIN AppBundle\Entity\Star s WITH s.repo = v1.repo
+            LEFT JOIN AppBundle\Entity\Repo r WITH r.id = s.repo
+            WHERE v2.repo IS NULL
+            AND s.user = :userId
+            ORDER BY v1.createdAt DESC");
+
+        $query->setParameter('userId', $userId);
+
+        return $query->getArrayResult();
     }
 }

--- a/src/AppBundle/Repository/VersionRepository.php
+++ b/src/AppBundle/Repository/VersionRepository.php
@@ -37,7 +37,7 @@ class VersionRepository extends \Doctrine\ORM\EntityRepository
      * DQL query to retrieve last version of each repo starred by a user.
      * We use DQL because it was to complex to use a query builder.
      *
-     * @param  int $userId User ID
+     * @param int $userId User ID
      *
      * @return array
      */

--- a/src/AppBundle/Security/GithubAuthenticator.php
+++ b/src/AppBundle/Security/GithubAuthenticator.php
@@ -89,7 +89,7 @@ class GithubAuthenticator extends SocialAuthenticator
             new Message(json_encode($message))
         );
 
-        return new RedirectResponse($this->router->generate('homepage') . '?sync=1');
+        return new RedirectResponse($this->router->generate('dashboard') . '?sync=1');
     }
 
     public function start(Request $request, AuthenticationException $authException = null)

--- a/src/AppBundle/Twig/RepoVersionExtension.php
+++ b/src/AppBundle/Twig/RepoVersionExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AppBundle\Twig;
+
+/**
+ * Took a repo with version information to display a link to that version on Github.
+ */
+class RepoVersionExtension extends \Twig_Extension
+{
+    public function getFilters()
+    {
+        return [
+            new \Twig_SimpleFilter('link_to_version', [$this, 'linkToVersion']),
+        ];
+    }
+
+    public function linkToVersion(array $repo)
+    {
+        if (!isset($repo['fullName']) || !isset($repo['tagName'])) {
+            return;
+        }
+
+        return 'https://github.com/' . $repo['fullName'] . '/releases/' . $repo['tagName'];
+    }
+
+    public function getName()
+    {
+        return 'repo_verson_extension';
+    }
+}

--- a/tests/AppBundle/Consumer/SyncUserRepoTest.php
+++ b/tests/AppBundle/Consumer/SyncUserRepoTest.php
@@ -14,8 +14,9 @@ use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Psr\Log\NullLogger;
 use Swarrot\Broker\Message;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class SyncUserRepoTest extends \PHPUnit_Framework_TestCase
+class SyncUserRepoTest extends WebTestCase
 {
     public function testProcessNoUser()
     {
@@ -106,7 +107,7 @@ class SyncUserRepoTest extends \PHPUnit_Framework_TestCase
             ->with(['fullName' => 'removed/star-repo'])
             ->willReturn($star);
 
-        $mock = new MockHandler([
+        $responses = new MockHandler([
             // first /user/starred
             new Response(200, ['Content-Type' => 'application/json'], json_encode([[
                 'description' => 'banditore',
@@ -119,11 +120,96 @@ class SyncUserRepoTest extends \PHPUnit_Framework_TestCase
             ]])),
             // /rate_limit
             new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => 10]]])),
-            // second /user/starred
+            // second /user/starred will return empty response which means, we reached the last page
             new Response(200, ['Content-Type' => 'application/json'], json_encode([])),
         ]);
 
-        $clientHandler = HandlerStack::create($mock);
+        $githubClient = $this->getMockClient($responses);
+
+        $logger = new Logger('foo');
+        $logHandler = new TestHandler();
+        $logger->pushHandler($logHandler);
+
+        $processor = new SyncUserRepo(
+            $em,
+            $userRepository,
+            $starRepository,
+            $repoRepository,
+            $logger
+        );
+        $processor->setClient($githubClient);
+
+        $processor->process(new Message(json_encode(['user_id' => 123])), []);
+
+        $records = $logHandler->getRecords();
+
+        $this->assertSame('Consume banditore.sync_user_repo message', $records[0]['message']);
+        $this->assertSame('    sync 1 starred repos', $records[1]['message']);
+        $this->assertSame('Removed stars: 1', $records[2]['message']);
+        $this->assertSame('Synced repos: 1', $records[3]['message']);
+    }
+
+    public function testFunctionalConsumer()
+    {
+        $responses = new MockHandler([
+            // first /user/starred
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([[
+                'description' => 'banditore',
+                'name' => 'banditore',
+                'full_name' => 'j0k3r/banditore',
+                'id' => 777,
+                'owner' => [
+                    'avatar_url' => 'http://avatar.api/banditore.jpg',
+                ],
+            ]])),
+            // /rate_limit
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => 10]]])),
+            // second /user/starred
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([[
+                'description' => 'This is a test repo',
+                'name' => 'test',
+                'full_name' => 'test/test',
+                'id' => 666,
+                'owner' => [
+                    'avatar_url' => 'http://0.0.0.0/test.jpg',
+                ],
+            ]])),
+            // /rate_limit
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => 8]]])),
+            // third /user/starred will return empty response which means, we reached the last page
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([])),
+        ]);
+
+        $githubClient = $this->getMockClient($responses);
+
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $processor = $container->get('banditore.consumer.sync_user_repo');
+        $processor->setClient($githubClient);
+
+        // before import
+        $stars = $container->get('banditore.repository.star')->findAllByUser(123);
+        $this->assertCount(2, $stars, 'User 123 has 2 starred repos');
+        $this->assertSame('symfony/symfony', $stars[0], 'User 123 has "symfony/symfony" starred repo');
+        $this->assertSame('test/test', $stars[1], 'User 123 has "test/test" starred repo');
+
+        $processor->process(new Message(json_encode(['user_id' => 123])), []);
+
+        $repo = $container->get('banditore.repository.repo')->find(777);
+        $this->assertNotNull($repo, 'Imported repo with id 777 exists');
+        $this->assertSame('j0k3r/banditore', $repo->getFullName(), 'Imported repo with id 777 exists');
+
+        // validate that `test/test` association got removed
+        $stars = $container->get('banditore.repository.star')->findAllByUser(123);
+        $this->assertCount(2, $stars, 'User 123 has 2 starred repos');
+        $this->assertSame('test/test', $stars[0], 'User 123 has "test/test" starred repo');
+        $this->assertSame('j0k3r/banditore', $stars[1], 'User 123 has "j0k3r/banditore" starred repo');
+    }
+
+    private function getMockClient($responses)
+    {
+        $clientHandler = HandlerStack::create($responses);
         $guzzleClient = new Client([
             'base_uri' => 'https://github.api',
             'handler' => $clientHandler,
@@ -151,26 +237,6 @@ class SyncUserRepoTest extends \PHPUnit_Framework_TestCase
             ->method('getHttpClient')
             ->will($this->returnValue($guzzleClient));
 
-        $logger = new Logger('foo');
-        $logHandler = new TestHandler();
-        $logger->pushHandler($logHandler);
-
-        $processor = new SyncUserRepo(
-            $em,
-            $userRepository,
-            $starRepository,
-            $repoRepository,
-            $logger
-        );
-        $processor->setClient($githubClient);
-
-        $processor->process(new Message(json_encode(['user_id' => 123])), []);
-
-        $records = $logHandler->getRecords();
-
-        $this->assertSame('Consume banditore.sync_user_repo message', $records[0]['message']);
-        $this->assertSame('    sync 1 starred repos', $records[1]['message']);
-        $this->assertSame('Removed stars: 1', $records[2]['message']);
-        $this->assertSame('Synced repos: 1', $records[3]['message']);
+        return $githubClient;
     }
 }

--- a/tests/AppBundle/Consumer/SyncUserRepoTest.php
+++ b/tests/AppBundle/Consumer/SyncUserRepoTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\AppBundle\Consumer;
+
+use AppBundle\Consumer\SyncUserRepo;
+use AppBundle\Entity\User;
+use Github\Api\CurrentUser;
+use Github\Api\RateLimit;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Psr\Log\NullLogger;
+use Swarrot\Broker\Message;
+
+class SyncUserRepoTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcessNoUser()
+    {
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $userRepository = $this->getMockBuilder('AppBundle\Repository\UserRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $userRepository->expects($this->once())
+            ->method('find')
+            ->with(123)
+            ->willReturn(null);
+
+        $starRepository = $this->getMockBuilder('AppBundle\Repository\StarRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $repoRepository = $this->getMockBuilder('AppBundle\Repository\RepoRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $githubClient = $this->getMockBuilder('Github\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $githubClient->expects($this->never())
+            ->method('authenticate');
+
+        $processor = new SyncUserRepo(
+            $em,
+            $userRepository,
+            $starRepository,
+            $repoRepository,
+            new NullLogger()
+        );
+        $processor->setClient($githubClient);
+
+        $processor->process(new Message(json_encode(['user_id' => 123])), []);
+    }
+
+    public function testProcessSuccessfulMessage()
+    {
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $user = new User();
+        $user->setId(123);
+        $user->setUsername('bob');
+        $user->setName('Bobby');
+
+        $userRepository = $this->getMockBuilder('AppBundle\Repository\UserRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $userRepository->expects($this->once())
+            ->method('find')
+            ->with(123)
+            ->will($this->returnValue($user));
+
+        $starRepository = $this->getMockBuilder('AppBundle\Repository\StarRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $starRepository->expects($this->once())
+            ->method('findAllByUser')
+            ->with(123)
+            ->willReturn(['removed/star-repo']);
+
+        $star = $this->getMockBuilder('AppBundle\Entity\Star')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $star->expects($this->once())
+            ->method('getId')
+            ->with()
+            ->willReturn(1);
+
+        $repoRepository = $this->getMockBuilder('AppBundle\Repository\RepoRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $repoRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['fullName' => 'removed/star-repo'])
+            ->willReturn($star);
+
+        $mock = new MockHandler([
+            // first /user/starred
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([[
+                'description' => 'banditore',
+                'name' => 'banditore',
+                'full_name' => 'j0k3r/banditore',
+                'id' => 666,
+                'owner' => [
+                    'avatar_url' => 'http://avatar.api/banditore.jpg',
+                ],
+            ]])),
+            // /rate_limit
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => 10]]])),
+            // second /user/starred
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([])),
+        ]);
+
+        $clientHandler = HandlerStack::create($mock);
+        $guzzleClient = new Client([
+            'base_uri' => 'https://github.api',
+            'handler' => $clientHandler,
+        ]);
+
+        $githubClient = $this->getMockBuilder('Github\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $githubUser = new CurrentUser($githubClient);
+        $githubRate = new RateLimit($githubClient);
+
+        $githubClient->expects($this->any())
+            ->method('api')
+            ->will($this->returnCallback(function ($arg) use ($githubUser, $githubRate) {
+                switch ($arg) {
+                    case 'current_user':
+                        return $githubUser;
+                    case 'rate_limit':
+                        return $githubRate;
+                }
+            }));
+
+        $githubClient->expects($this->any())
+            ->method('getHttpClient')
+            ->will($this->returnValue($guzzleClient));
+
+        $logger = new Logger('foo');
+        $logHandler = new TestHandler();
+        $logger->pushHandler($logHandler);
+
+        $processor = new SyncUserRepo(
+            $em,
+            $userRepository,
+            $starRepository,
+            $repoRepository,
+            $logger
+        );
+        $processor->setClient($githubClient);
+
+        $processor->process(new Message(json_encode(['user_id' => 123])), []);
+
+        $records = $logHandler->getRecords();
+
+        $this->assertSame('Consume banditore.sync_user_repo message', $records[0]['message']);
+        $this->assertSame('    sync 1 starred repos', $records[1]['message']);
+        $this->assertSame('Removed stars: 1', $records[2]['message']);
+        $this->assertSame('Synced repos: 1', $records[3]['message']);
+    }
+}

--- a/tests/AppBundle/Controller/DefaultControllerTest.php
+++ b/tests/AppBundle/Controller/DefaultControllerTest.php
@@ -2,17 +2,76 @@
 
 namespace Tests\AppBundle\Controller;
 
+use AppBundle\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 
 class DefaultControllerTest extends WebTestCase
 {
-    public function testIndex()
+    private $client = null;
+
+    public function setUp()
     {
-        $client = static::createClient();
+        $this->client = static::createClient();
+    }
 
-        $crawler = $client->request('GET', '/');
+    public function testIndexNotLoggedIn()
+    {
+        $crawler = $this->client->request('GET', '/');
 
-        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
         $this->assertContains('Bandito.re', $crawler->filter('a.pure-menu-heading')->text());
+    }
+
+    public function testIndexLoggedIn()
+    {
+        $user = $this->client->getContainer()->get('banditore.repository.user')->find(123);
+
+        $this->logIn($user);
+        $this->client->request('GET', '/');
+
+        $this->assertSame(302, $this->client->getResponse()->getStatusCode());
+        $this->assertContains('dashboard', $this->client->getResponse()->getTargetUrl());
+    }
+
+    public function testDashboardNotLoggedIn()
+    {
+        $this->client->request('GET', '/dashboard');
+
+        $this->assertSame(302, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testDashboard()
+    {
+        $user = $this->client->getContainer()->get('banditore.repository.user')->find(123);
+
+        $this->logIn($user);
+        $crawler = $this->client->request('GET', '/dashboard');
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $header = $crawler->filter('.header')->text();
+        $this->assertContains('View it on Github', $header, 'Link to Github is here');
+        $this->assertContains('Logged in as admin', $header, 'Info about logged in user is here');
+        $this->assertContains('Your RSS feed', $header, 'RSS feed is here');
+
+        $table = $crawler->filter('table')->text();
+        $this->assertContains('test/test', $table, 'Repo test/test exist in a table');
+        $this->assertContains('First release (v1.0.0)', $table, 'First release of test/test exist in a table');
+    }
+
+    private function logIn(User $user)
+    {
+        $session = $this->client->getContainer()->get('session');
+
+        $firewall = 'main';
+
+        $token = new PostAuthenticationGuardToken($user, $firewall, ['ROLE_ADMIN']);
+        $session->set('_security_' . $firewall, serialize($token));
+        $session->save();
+
+        $cookie = new Cookie($session->getName(), $session->getId());
+        $this->client->getCookieJar()->set($cookie);
     }
 }

--- a/tests/AppBundle/Twig/RepoVersionExtensionTest.php
+++ b/tests/AppBundle/Twig/RepoVersionExtensionTest.php
@@ -11,6 +11,7 @@ class RepoVersionExtensionTest extends \PHPUnit_Framework_TestCase
         $ext = new RepoVersionExtension();
 
         $this->assertSame('repo_verson_extension', $ext->getName());
+        $this->assertCount(1, $ext->getFilters(), 'Extension has only one filter');
 
         $this->assertNull($ext->linkToVersion([]));
         $this->assertNull($ext->linkToVersion(['fullName' => 'test/test']));

--- a/tests/AppBundle/Twig/RepoVersionExtensionTest.php
+++ b/tests/AppBundle/Twig/RepoVersionExtensionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\AppBundle\Twig;
+
+use AppBundle\Twig\RepoVersionExtension;
+
+class RepoVersionExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        $ext = new RepoVersionExtension();
+
+        $this->assertSame('repo_verson_extension', $ext->getName());
+
+        $this->assertNull($ext->linkToVersion([]));
+        $this->assertNull($ext->linkToVersion(['fullName' => 'test/test']));
+        $this->assertNull($ext->linkToVersion(['tagName' => 'v1.0.0']));
+
+        $this->assertSame('https://github.com/test/test/releases/v1.0.0', $ext->linkToVersion(['fullName' => 'test/test', 'tagName' => 'v1.0.0']));
+    }
+}

--- a/web/css/banditore.css
+++ b/web/css/banditore.css
@@ -140,7 +140,7 @@ a.pure-button-primary:hover {
  */
 .splash-container {
     background: #2B687F;
-    padding: 130px 0 70px;
+    padding: 80px 0 70px;
 }
 
 .splash {
@@ -181,12 +181,13 @@ a.pure-button-primary:hover {
 .content-wrapper {
     /* These styles are required for the "scroll-over" effect */
     /*position: absolute;*/
-    top: 69%;
+    /*top: 69%;*/
     /*width: 100%;*/
     /*min-height: 12%;*/
     /*z-index: 2;*/
     background: #2B687F;
     margin: 0 auto;
+    padding-top: 51px;
 }
 
 /* We want to give the content area some more padding */
@@ -216,10 +217,18 @@ a.pure-button-primary:hover {
     margin-right: 7px;
 }
 
+.pure-table {
+    margin: 0 auto;
+}
+
 /* This is the class used for the dark-background areas. */
 .ribbon {
     background: #10556B;
     color: #aaa;
+}
+
+img.repo-avatar {
+    vertical-align: middle;
 }
 
 .image-productivity,


### PR DESCRIPTION
Instead of retrieve repos & stars from a user right after the connection, use a broker to push a message to retrieve them later.
It'll avoid user to wait for the page to finish loading before being able to retrieve its feed.

In a next PR I'll add a message about sync in progress to the user. But it'll require to change a bit the homepage when a user is connected.

- [x] Add real test with database access