### PR TITLE
Add Github Client Discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ install:
     - composer --prefer-dist install --no-interaction -o --no-progress
 
 before_script:
-    - ./bin/console doctrine:database:create --env=test
-    - ./bin/console doctrine:schema:create --env=test
-    - ./bin/console doctrine:fixtures:load --env=test -n
+    - php bin/console doctrine:database:create --env=test
+    - php bin/console doctrine:schema:create --env=test
+    - php bin/console doctrine:fixtures:load --env=test -n
     - ./bin/rabbit vhost:mapping:create -p guest app/config/rabbit_vhost.yml
     - if [ "$COVERAGE" = "run" ]; then PHPUNIT_FLAGS="--coverage-clover build/logs/clover.xml"; fi;
 

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -11,10 +11,13 @@ services:
             - "@swarrot.publisher"
 
     banditore.client.redis:
-        class: Redis
-        calls:
-            - [ connect, [ "%redis_host%", "%redis_port%" ] ]
-            - [ select, [ "%redis_database%" ] ]
+        class: Predis\Client
+        arguments:
+            -
+                host: '%redis_host%'
+                port: '%redis_port%'
+                schema: tcp
+                database: "%redis_database%"
 
     # repository as a service
     banditore.repository.repo:
@@ -41,11 +44,18 @@ services:
         arguments:
             - AppBundle:Version
 
-    # global Github application client
-    banditore.client.github.application:
+    banditore.client.github:
         class: Github\Client
-        calls:
-            - [ authenticate, [ "%github_client_id%", "%github_client_secret%", !php/const:Github\Client::AUTH_URL_CLIENT_ID ] ]
+        factory: [ "@banditore.github.client_discovery", find ]
+
+    banditore.github.client_discovery:
+        class: AppBundle\Github\ClientDiscovery
+        arguments:
+            - "@banditore.repository.user"
+            - "@banditore.client.redis"
+            - "%github_client_id%"
+            - "%github_client_secret%"
+            - "@logger"
 
     banditore.writer.webfeeds:
         class: AppBundle\Webfeeds\WebfeedsWriter
@@ -93,10 +103,11 @@ services:
             - "@banditore.repository.repo"
             - "@banditore.repository.version"
             - "@banditore.pubsubhubbub.publisher"
+            - "@banditore.client.github"
             - "@logger"
-        calls:
-            - [ setClient, [ "@banditore.client.github.application" ] ]
-            - [ setClientCache, [ "@banditore.client.redis" ] ]
+        # to avoid triggering Github Client Discovery
+        # which will make a doctrine query on Travis because the default limit to Github will be reached
+        lazy: true
 
     # twig extensions
     banditore.twig_extension.repo_version:

--- a/composer.json
+++ b/composer.json
@@ -33,23 +33,26 @@
         "league/oauth2-github": "^2.0",
         "knplabs/github-api": "^2.0",
         "php-http/guzzle6-adapter": "^1.1",
+        "php-http/cache-plugin": "^1.3@dev",
         "knpuniversity/oauth2-client-bundle": "^1.9",
         "ramsey/uuid": "^3.5",
-        "cache/redis-adapter": "^0.4.2",
+        "cache/predis-adapter": "^0.4.2",
         "odolbeau/rabbit-mq-admin-toolkit": "^3.2",
         "swarrot/swarrot-bundle": "^1.4",
         "php-amqplib/php-amqplib": "^2.6",
         "twig/extensions": "^1.4",
         "doctrine/doctrine-migrations-bundle": "^1.2",
         "sentry/sentry-symfony": "^0.7.1",
-        "ekino/newrelic-bundle": "^1.3"
+        "ekino/newrelic-bundle": "^1.3",
+        "ocramius/proxy-manager": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.0",
         "sensio/generator-bundle": "^3.0",
         "symfony/phpunit-bridge": "^3.0",
         "doctrine/doctrine-fixtures-bundle": "^2.3",
-        "satooshi/php-coveralls": "dev-master"
+        "satooshi/php-coveralls": "dev-master",
+        "m6web/redis-mock": "dev-predis-1.x"
     },
     "scripts": {
         "symfony-scripts": [
@@ -72,6 +75,12 @@
         },
         "bin-dir": "bin"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/j0k3r/RedisMock"
+        }
+    ],
     "extra": {
         "symfony-app-dir": "app",
         "symfony-bin-dir": "bin",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f7ca83a948d6d1f502b07626f40d24c",
+    "content-hash": "e1f303d102ff33fcfbd6e173d83a4a32",
     "packages": [
         {
             "name": "cache/adapter-common",
@@ -119,17 +119,17 @@
             "time": "2016-08-07T14:49:33+00:00"
         },
         {
-            "name": "cache/redis-adapter",
+            "name": "cache/predis-adapter",
             "version": "0.4.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-cache/redis-adapter.git",
-                "reference": "55872608728f0f52ba996c42c360e18631ef6f63"
+                "url": "https://github.com/php-cache/predis-adapter.git",
+                "reference": "12038202d125d50a259737863aaf2a56f8cc9ee0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/redis-adapter/zipball/55872608728f0f52ba996c42c360e18631ef6f63",
-                "reference": "55872608728f0f52ba996c42c360e18631ef6f63",
+                "url": "https://api.github.com/repos/php-cache/predis-adapter/zipball/12038202d125d50a259737863aaf2a56f8cc9ee0",
+                "reference": "12038202d125d50a259737863aaf2a56f8cc9ee0",
                 "shasum": ""
             },
             "require": {
@@ -137,6 +137,7 @@
                 "cache/hierarchical-cache": "^0.3",
                 "cache/taggable-cache": "^0.4",
                 "php": "^5.5 || ^7.0",
+                "predis/predis": "^1.0",
                 "psr/cache": "^1.0"
             },
             "provide": {
@@ -146,13 +147,10 @@
                 "cache/integration-tests": "^0.11",
                 "phpunit/phpunit": "^4.0 || ^5.1"
             },
-            "suggest": {
-                "ext-redis": "The extension required to use this pool."
-            },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Cache\\Adapter\\Redis\\": ""
+                    "Cache\\Adapter\\Predis\\": ""
                 },
                 "exclude-from-classmap": [
                     "/Tests/"
@@ -174,16 +172,16 @@
                     "homepage": "https://github.com/nyholm"
                 }
             ],
-            "description": "A PSR-6 cache implementation using Redis (PhpRedis). This implementation supports tags",
+            "description": "A PSR-6 cache implementation using Redis (Predis). This implementation supports tags",
             "homepage": "http://www.php-cache.com/en/latest/",
             "keywords": [
                 "cache",
-                "phpredis",
+                "predis",
                 "psr-6",
                 "redis",
                 "tag"
             ],
-            "time": "2016-08-07T15:04:55+00:00"
+            "time": "2016-09-28T12:11:35+00:00"
         },
         {
             "name": "cache/taggable-cache",
@@ -2020,16 +2018,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.7",
+            "version": "v2.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "b5ea1ef3d8ff10c307ba8c5945c2f134e503278f"
+                "reference": "6968531206671f94377b01dc7888d5d1b858a01b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/b5ea1ef3d8ff10c307ba8c5945c2f134e503278f",
-                "reference": "b5ea1ef3d8ff10c307ba8c5945c2f134e503278f",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/6968531206671f94377b01dc7888d5d1b858a01b",
+                "reference": "6968531206671f94377b01dc7888d5d1b858a01b",
                 "shasum": ""
             },
             "require": {
@@ -2064,7 +2062,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-02-27T17:11:23+00:00"
+            "time": "2017-03-03T20:43:42+00:00"
         },
         {
             "name": "php-amqplib/php-amqplib",
@@ -2138,16 +2136,16 @@
         },
         {
             "name": "php-http/cache-plugin",
-            "version": "v1.2.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/cache-plugin.git",
-                "reference": "b4e421cb5214ad9ef8b25bb32214ed4b71a8b356"
+                "reference": "7110f6c4e0db3e86d176234cdf1d840d4cf94778"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/cache-plugin/zipball/b4e421cb5214ad9ef8b25bb32214ed4b71a8b356",
-                "reference": "b4e421cb5214ad9ef8b25bb32214ed4b71a8b356",
+                "url": "https://api.github.com/repos/php-http/cache-plugin/zipball/7110f6c4e0db3e86d176234cdf1d840d4cf94778",
+                "reference": "7110f6c4e0db3e86d176234cdf1d840d4cf94778",
                 "shasum": ""
             },
             "require": {
@@ -2164,7 +2162,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -2190,7 +2188,7 @@
                 "httplug",
                 "plugin"
             ],
-            "time": "2016-08-16T12:12:50+00:00"
+            "time": "2017-02-27 09:28:48"
         },
         {
             "name": "php-http/client-common",
@@ -2255,16 +2253,16 @@
         },
         {
             "name": "php-http/discovery",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "cc5669d9cb51170ad0278a3b984cd3c7894d6ff9"
+                "reference": "6b33475a3239439bc7ced287d0de0bb82e04d2f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/cc5669d9cb51170ad0278a3b984cd3c7894d6ff9",
-                "reference": "cc5669d9cb51170ad0278a3b984cd3c7894d6ff9",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/6b33475a3239439bc7ced287d0de0bb82e04d2f0",
+                "reference": "6b33475a3239439bc7ced287d0de0bb82e04d2f0",
                 "shasum": ""
             },
             "require": {
@@ -2313,7 +2311,7 @@
                 "message",
                 "psr7"
             ],
-            "time": "2017-02-12T08:49:24+00:00"
+            "time": "2017-03-02T06:56:00+00:00"
         },
         {
             "name": "php-http/guzzle6-adapter",
@@ -2601,6 +2599,56 @@
             "time": "2016-01-26T13:27:02+00:00"
         },
         {
+            "name": "predis/predis",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nrk/predis.git",
+                "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nrk/predis/zipball/f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "suggest": {
+                "ext-curl": "Allows access to Webdis when paired with phpiredis",
+                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Predis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniele Alessandri",
+                    "email": "suppakilla@gmail.com",
+                    "homepage": "http://clorophilla.net"
+                }
+            ],
+            "description": "Flexible and feature-complete Redis client for PHP and HHVM",
+            "homepage": "http://github.com/nrk/predis",
+            "keywords": [
+                "nosql",
+                "predis",
+                "redis"
+            ],
+            "time": "2016-06-16T16:22:20+00:00"
+        },
+        {
             "name": "psr/cache",
             "version": "1.0.1",
             "source": {
@@ -2879,16 +2927,16 @@
         },
         {
             "name": "sensio/framework-extra-bundle",
-            "version": "v3.0.22",
+            "version": "v3.0.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "1c66c2e3b8f17f06178142386aff5a9f8057a104"
+                "reference": "d3601fd5709168ace7a1ca6eefa2619a1632b7f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/1c66c2e3b8f17f06178142386aff5a9f8057a104",
-                "reference": "1c66c2e3b8f17f06178142386aff5a9f8057a104",
+                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/d3601fd5709168ace7a1ca6eefa2619a1632b7f7",
+                "reference": "d3601fd5709168ace7a1ca6eefa2619a1632b7f7",
                 "shasum": ""
             },
             "require": {
@@ -2945,7 +2993,7 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2017-02-15T06:52:30+00:00"
+            "time": "2017-03-02T20:17:28+00:00"
         },
         {
             "name": "sensiolabs/security-checker",
@@ -4106,16 +4154,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.1.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "2c69f4d424f85062fe40f7689797d6d32c76b711"
+                "reference": "e0e33ce4eaf59ba77ead9ce45256692aa29ecb38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/2c69f4d424f85062fe40f7689797d6d32c76b711",
-                "reference": "2c69f4d424f85062fe40f7689797d6d32c76b711",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/e0e33ce4eaf59ba77ead9ce45256692aa29ecb38",
+                "reference": "e0e33ce4eaf59ba77ead9ce45256692aa29ecb38",
                 "shasum": ""
             },
             "require": {
@@ -4128,6 +4176,7 @@
                 "symfony/finder": "^2.2 || ^3.0",
                 "symfony/polyfill-php54": "^1.0",
                 "symfony/polyfill-php55": "^1.3",
+                "symfony/polyfill-xml": "^1.3",
                 "symfony/process": "^2.3 || ^3.0",
                 "symfony/stopwatch": "^2.5 || ^3.0"
             },
@@ -4136,8 +4185,13 @@
             },
             "require-dev": {
                 "gecko-packages/gecko-php-unit": "^2.0",
+                "justinrainbow/json-schema": "^5.0",
                 "phpunit/phpunit": "^4.5|^5",
-                "satooshi/php-coveralls": "^1.0"
+                "satooshi/php-coveralls": "^1.0",
+                "symfony/phpunit-bridge": "^3.2"
+            },
+            "suggest": {
+                "ext-xml": "For better performance."
             },
             "bin": [
                 "php-cs-fixer"
@@ -4163,7 +4217,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2017-02-10T15:37:50+00:00"
+            "time": "2017-03-03T08:03:57+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -4206,6 +4260,53 @@
                 "password"
             ],
             "time": "2014-11-20T16:49:30+00:00"
+        },
+        {
+            "name": "m6web/redis-mock",
+            "version": "dev-predis-1.x",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/j0k3r/RedisMock.git",
+                "reference": "c3352225364174068c3144169d4e4badfc13dff8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/j0k3r/RedisMock/zipball/c3352225364174068c3144169d4e4badfc13dff8",
+                "reference": "c3352225364174068c3144169d4e4badfc13dff8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "atoum/atoum": "master-dev",
+                "predis/predis": "~0.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "M6Web\\Component\\RedisMock": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "M6Web",
+                    "email": "opensource@m6web.fr",
+                    "homepage": "http://tech.m6web.fr/"
+                }
+            ],
+            "description": "Library providing a PHP mock for Redis",
+            "keywords": [
+                "mock",
+                "redis"
+            ],
+            "support": {
+                "source": "https://github.com/j0k3r/RedisMock/tree/predis-1.x"
+            },
+            "time": "2017-03-03T14:29:12+00:00"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -4324,16 +4425,16 @@
         },
         {
             "name": "sensio/generator-bundle",
-            "version": "v3.1.2",
+            "version": "v3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioGeneratorBundle.git",
-                "reference": "ec278c0bd530edf155c4a00900577b5cb80f559e"
+                "reference": "c76c7833ed5ffe0f5aeef15e13939ddb59a684eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/ec278c0bd530edf155c4a00900577b5cb80f559e",
-                "reference": "ec278c0bd530edf155c4a00900577b5cb80f559e",
+                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/c76c7833ed5ffe0f5aeef15e13939ddb59a684eb",
+                "reference": "c76c7833ed5ffe0f5aeef15e13939ddb59a684eb",
                 "shasum": ""
             },
             "require": {
@@ -4372,7 +4473,7 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "time": "2016-12-05T16:01:19+00:00"
+            "time": "2017-03-03T15:22:50+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
@@ -4546,12 +4647,72 @@
                 "shim"
             ],
             "time": "2016-11-14T01:06:16+00:00"
+        },
+        {
+            "name": "symfony/polyfill-xml",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-xml.git",
+                "reference": "64b6a864f18ab4fddad49f5025f805f6781dfabd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-xml/zipball/64b6a864f18ab4fddad49f5025f805f6781dfabd",
+                "reference": "64b6a864f18ab4fddad49f5025f805f6781dfabd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-xml": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Xml\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for xml's utf8_encode and utf8_decode functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-11-14T01:06:16+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "satooshi/php-coveralls": 20
+        "php-http/cache-plugin": 20,
+        "satooshi/php-coveralls": 20,
+        "m6web/redis-mock": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="KERNEL_DIR" value="app/" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
     </php>
 
     <testsuites>

--- a/src/AppBundle/Consumer/SyncVersions.php
+++ b/src/AppBundle/Consumer/SyncVersions.php
@@ -7,7 +7,6 @@ use AppBundle\Entity\Version;
 use AppBundle\PubSubHubbub\Publisher;
 use AppBundle\Repository\RepoRepository;
 use AppBundle\Repository\VersionRepository;
-use Cache\Adapter\Redis\RedisCachePool;
 use Doctrine\ORM\EntityManager;
 use Github\Client;
 use Psr\Log\LoggerInterface;
@@ -26,36 +25,14 @@ class SyncVersions implements ProcessorInterface
     private $logger;
     private $client;
 
-    public function __construct(EntityManager $em, RepoRepository $repoRepository, VersionRepository $versionRepository, Publisher $pubsubhubbub, LoggerInterface $logger)
+    public function __construct(EntityManager $em, RepoRepository $repoRepository, VersionRepository $versionRepository, Publisher $pubsubhubbub, Client $client, LoggerInterface $logger)
     {
         $this->em = $em;
         $this->repoRepository = $repoRepository;
         $this->versionRepository = $versionRepository;
         $this->pubsubhubbub = $pubsubhubbub;
-        $this->logger = $logger;
-        $this->client = new Client();
-    }
-
-    /**
-     * Mostly for test to be able to override the client.
-     *
-     * @todo refacto to use a global client
-     *
-     * @param Client $client Github client
-     */
-    public function setClient(Client $client)
-    {
         $this->client = $client;
-    }
-
-    /**
-     * Add http cache to the Github client.
-     *
-     * @param \Redis $redis
-     */
-    public function setClientCache(\Redis $redis)
-    {
-        $this->client->addCache(new RedisCachePool($redis));
+        $this->logger = $logger;
     }
 
     public function process(Message $message, array $options)

--- a/src/AppBundle/Github/ClientDiscovery.php
+++ b/src/AppBundle/Github/ClientDiscovery.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace AppBundle\Github;
+
+use AppBundle\Repository\UserRepository;
+use Cache\Adapter\Predis\PredisCachePool;
+use Github\Client as GithubClient;
+use Http\Client\Exception\HttpException;
+use Predis\Client as RedisClient;
+use Psr\Log\LoggerInterface;
+
+/**
+ * This class aim to find the best authenticated method to avoid hitting the Github rate limit.
+ * We first try with the default application authentication.
+ * And if it fails, we'll try each user until we find one with enough rate limit.
+ * In fact, the more user in database, the bigger chance to never hit the rate limit.
+ */
+class ClientDiscovery
+{
+    const THRESHOLD_BAD_AUTH = 50;
+
+    private $userRepository;
+    private $redis;
+    private $clientId;
+    private $clientSecret;
+    private $logger;
+    private $client;
+
+    public function __construct(UserRepository $userRepository, RedisClient $redis, $clientId, $clientSecret, LoggerInterface $logger)
+    {
+        $this->userRepository = $userRepository;
+        $this->redis = $redis;
+        $this->clientId = $clientId;
+        $this->clientSecret = $clientSecret;
+        $this->logger = $logger;
+
+        $this->client = new GithubClient();
+    }
+
+    /**
+     * Allow to override Github client.
+     * Only used in test.
+     *
+     * @param GithubClient $client
+     */
+    public function setGithubClient(GithubClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Find the best authentication to use:
+     *     - check the rate limit of the application default client (which should be used in most case)
+     *     - if the rate limit is too low for the application client, loop on all user to check their rate limit
+     *     - if none client have enough rate limit, we'll have a problem to perform further request, stop every thing !
+     *
+     * @return GithubClient
+     */
+    public function find()
+    {
+        // attache the cache in anycase
+        $this->client->addCache(
+            new PredisCachePool($this->redis),
+            [
+                // the default config include "private" to avoid caching request with this header
+                // since we can use a user token, Github will return a "private" but we want to cache that request
+                // it's safe because we don't require critical user value
+                'respect_response_cache_directives' => ['no-cache', 'max-age', 'no-store'],
+            ]
+        );
+
+        // try with the application default client
+        $this->client->authenticate($this->clientId, $this->clientSecret, GithubClient::AUTH_URL_CLIENT_ID);
+
+        if ($this->getRateLimits() >= self::THRESHOLD_BAD_AUTH) {
+            $this->logger->info('RateLimit ok with default application');
+
+            return $this->client;
+        }
+
+        // if it doesn't work, try with all user tokens
+        // when at least one is ok, use it!
+        $users = $this->userRepository->findAllTokens();
+        foreach ($users as $user) {
+            $this->client->authenticate($user['accessToken'], null, GithubClient::AUTH_HTTP_TOKEN);
+
+            if ($this->getRateLimits() >= self::THRESHOLD_BAD_AUTH) {
+                $this->logger->info('RateLimit ok with user: ' . $user['username']);
+
+                return $this->client;
+            }
+        }
+
+        throw new \RuntimeException('No way to authenticate a client with enough rate limit remaining :(');
+    }
+
+    /**
+     * Retrieve rate limit for the current authenticated client.
+     * It's in a separate method to be able to catch error in case of glimpse on the Github side.
+     *
+     * @return false|int
+     */
+    private function getRateLimits()
+    {
+        try {
+            $rateLimit = $this->client->api('rate_limit')->getRateLimits();
+
+            return $rateLimit['resources']['core']['remaining'];
+        } catch (HttpException $e) {
+            $this->logger->error('RateLimit call goes bad.', ['exception' => $e]);
+
+            return false;
+        }
+    }
+}

--- a/src/AppBundle/Repository/UserRepository.php
+++ b/src/AppBundle/Repository/UserRepository.php
@@ -47,4 +47,20 @@ class UserRepository extends \Doctrine\ORM\EntityRepository
 
         return $return;
     }
+
+    /**
+     * Retrieve all tokens available.
+     * This is used for the GithubClientDiscovery.
+     *
+     * @return array
+     */
+    public function findAllTokens()
+    {
+        return $this->createQueryBuilder('u')
+            ->select('u.id', 'u.username', 'u.accessToken')
+            ->getQuery()
+            ->useResultCache(true)
+            ->setResultCacheLifetime(10 * 60)
+            ->getArrayResult();
+    }
 }

--- a/tests/AppBundle/Consumer/SyncVersionsTest.php
+++ b/tests/AppBundle/Consumer/SyncVersionsTest.php
@@ -55,9 +55,9 @@ class SyncVersionsTest extends WebTestCase
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
+            $githubClient,
             new NullLogger()
         );
-        $processor->setClient($githubClient);
 
         $processor->process(new Message(json_encode(['repo_id' => 123])), []);
     }
@@ -250,9 +250,9 @@ class SyncVersionsTest extends WebTestCase
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
+            $githubClient,
             $logger
         );
-        $processor->setClient($githubClient);
 
         $processor->process(new Message(json_encode(['repo_id' => 123])), []);
 
@@ -263,6 +263,9 @@ class SyncVersionsTest extends WebTestCase
         $this->assertSame('[10] <comment>3</comment> new versions for <info>bob/wow</info>', $records[2]['message']);
     }
 
+    /**
+     * Using only mocks for request.
+     */
     public function testFunctionalConsumer()
     {
         $clientHandler = HandlerStack::create($this->getWorkingResponses());
@@ -277,8 +280,10 @@ class SyncVersionsTest extends WebTestCase
         $client = static::createClient();
         $container = $client->getContainer();
 
+        // override factory to avoid real call to Github
+        $container->set('banditore.client.github', $githubClient);
+
         $processor = $container->get('banditore.consumer.sync_versions');
-        $processor->setClient($githubClient);
 
         $versions = $container->get('banditore.repository.version')->findBy(['repo' => 666]);
         $this->assertCount(1, $versions, 'Repo 666 has 1 version');

--- a/tests/AppBundle/Github/ClientDiscoveryTest.php
+++ b/tests/AppBundle/Github/ClientDiscoveryTest.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Tests\AppBundle\Github;
+
+use AppBundle\Github\ClientDiscovery;
+use Github\Client as GithubClient;
+use Github\HttpClient\Builder;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Http\Adapter\Guzzle6\Client as Guzzle6Client;
+use M6Web\Component\RedisMock\RedisMockFactory;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ClientDiscoveryTest extends WebTestCase
+{
+    public function testUseApplicationDefaultClient()
+    {
+        $userRepository = $this->getMockBuilder('AppBundle\Repository\UserRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $responses = new MockHandler([
+            // first rate_limit, it'll be ok because remaining > 50
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH + 1]]])),
+        ]);
+
+        $clientHandler = HandlerStack::create($responses);
+        $guzzleClient = new Client([
+            'handler' => $clientHandler,
+        ]);
+
+        $httpClient = new Guzzle6Client($guzzleClient);
+        $httpBuilder = new Builder($httpClient);
+        $githubClient = new GithubClient($httpBuilder);
+
+        $redis = (new RedisMockFactory())->getAdapter('Predis\Client', true);
+
+        $logger = new Logger('foo');
+        $logHandler = new TestHandler();
+        $logger->pushHandler($logHandler);
+
+        $disco = new ClientDiscovery(
+            $userRepository,
+            $redis,
+            'client_id',
+            'client_secret',
+            $logger
+        );
+        $disco->setGithubClient($githubClient);
+
+        $resClient = $disco->find();
+
+        $records = $logHandler->getRecords();
+
+        $this->assertInstanceOf('Github\Client', $resClient);
+        $this->assertSame('RateLimit ok with default application', $records[0]['message']);
+    }
+
+    public function testUseUserToken()
+    {
+        $userRepository = $this->getMockBuilder('AppBundle\Repository\UserRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $userRepository->expects($this->once())
+            ->method('findAllTokens')
+            ->willReturn([
+                [
+                    'id' => '123',
+                    'username' => 'bob',
+                    'accessToken' => '123123',
+                ],
+                [
+                    'id' => '456',
+                    'username' => 'lion',
+                    'accessToken' => '456456',
+                ],
+            ]);
+
+        $responses = new MockHandler([
+            // first rate_limit, it won't be ok because remaining < 50
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH - 40]]])),
+            // second rate_limit, it won't be ok because remaining < 50
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH - 20]]])),
+            // third rate_limit, it'll' be ok because remaining > 50
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH + 150]]])),
+        ]);
+
+        $clientHandler = HandlerStack::create($responses);
+        $guzzleClient = new Client([
+            'handler' => $clientHandler,
+        ]);
+
+        $httpClient = new Guzzle6Client($guzzleClient);
+        $httpBuilder = new Builder($httpClient);
+        $githubClient = new GithubClient($httpBuilder);
+
+        $redis = (new RedisMockFactory())->getAdapter('Predis\Client', true);
+
+        $logger = new Logger('foo');
+        $logHandler = new TestHandler();
+        $logger->pushHandler($logHandler);
+
+        $disco = new ClientDiscovery(
+            $userRepository,
+            $redis,
+            'client_id',
+            'client_secret',
+            $logger
+        );
+        $disco->setGithubClient($githubClient);
+
+        $resClient = $disco->find();
+
+        $records = $logHandler->getRecords();
+
+        $this->assertInstanceOf('Github\Client', $resClient);
+        $this->assertSame('RateLimit ok with user: lion', $records[0]['message']);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage No way to authenticate a client with enough rate limit remaining :(
+     */
+    public function testNoTokenAvailable()
+    {
+        $userRepository = $this->getMockBuilder('AppBundle\Repository\UserRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $userRepository->expects($this->once())
+            ->method('findAllTokens')
+            ->willReturn([
+                [
+                    'id' => '123',
+                    'username' => 'bob',
+                    'accessToken' => '123123',
+                ],
+            ]);
+
+        $responses = new MockHandler([
+            // first rate_limit, it won't be ok because remaining < 50
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH - 10]]])),
+            // second rate_limit, it won't be ok because remaining < 50
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH - 20]]])),
+        ]);
+
+        $clientHandler = HandlerStack::create($responses);
+        $guzzleClient = new Client([
+            'handler' => $clientHandler,
+        ]);
+
+        $httpClient = new Guzzle6Client($guzzleClient);
+        $httpBuilder = new Builder($httpClient);
+        $githubClient = new GithubClient($httpBuilder);
+
+        $redis = (new RedisMockFactory())->getAdapter('Predis\Client', true);
+
+        $disco = new ClientDiscovery(
+            $userRepository,
+            $redis,
+            'client_id',
+            'client_secret',
+            new NullLogger()
+        );
+        $disco->setGithubClient($githubClient);
+
+        $resClient = $disco->find();
+
+        $this->assertInstanceOf('Github\Client', $resClient);
+    }
+
+    public function testOneCallFail()
+    {
+        $userRepository = $this->getMockBuilder('AppBundle\Repository\UserRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $userRepository->expects($this->once())
+            ->method('findAllTokens')
+            ->willReturn([
+                [
+                    'id' => '123',
+                    'username' => 'bob',
+                    'accessToken' => '123123',
+                ],
+            ]);
+
+        $responses = new MockHandler([
+            // first rate_limit request fail (Github booboo)
+            new Response(400, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH + 100]]])),
+            // second rate_limit, it'll be ok because remaining > 50
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH + 100]]])),
+        ]);
+
+        $clientHandler = HandlerStack::create($responses);
+        $guzzleClient = new Client([
+            'handler' => $clientHandler,
+        ]);
+
+        $httpClient = new Guzzle6Client($guzzleClient);
+        $httpBuilder = new Builder($httpClient);
+        $githubClient = new GithubClient($httpBuilder);
+
+        $redis = (new RedisMockFactory())->getAdapter('Predis\Client', true);
+
+        $logger = new Logger('foo');
+        $logHandler = new TestHandler();
+        $logger->pushHandler($logHandler);
+
+        $disco = new ClientDiscovery(
+            $userRepository,
+            $redis,
+            'client_id',
+            'client_secret',
+            $logger
+        );
+        $disco->setGithubClient($githubClient);
+
+        $resClient = $disco->find();
+
+        $records = $logHandler->getRecords();
+
+        $this->assertInstanceOf('Github\Client', $resClient);
+        $this->assertSame('RateLimit call goes bad.', $records[0]['message']);
+        $this->assertSame('RateLimit ok with user: bob', $records[1]['message']);
+    }
+
+    /**
+     * Using only mocks for request.
+     */
+    public function testFunctionnal()
+    {
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        $responses = new MockHandler([
+            // first rate_limit request fail (Github booboo)
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH - 10]]])),
+            // second rate_limit, it'll be ok because remaining > 50
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH + 100]]])),
+        ]);
+
+        $clientHandler = HandlerStack::create($responses);
+        $guzzleClient = new Client([
+            'handler' => $clientHandler,
+        ]);
+
+        $httpClient = new Guzzle6Client($guzzleClient);
+        $httpBuilder = new Builder($httpClient);
+        $githubClient = new GithubClient($httpBuilder);
+
+        $disco = $container->get('banditore.github.client_discovery');
+        $disco->setGithubClient($githubClient);
+
+        $resClient = $disco->find();
+
+        $this->assertInstanceOf('Github\Client', $resClient);
+    }
+}


### PR DESCRIPTION
Find the best token to use to fetch data to avoid Rate Limit.

The goal is to find the best authenticated method to avoid hitting the Github rate limit.
We first try with the default application authentication (which might work 99% of the time).
And if it fails, we'll try each user until we find one with enough rate limit.
In fact, the more user in database, the bigger chance to never hit the rate limit (this is theorical).

This mostly to handle new users.
When a new user logged in for the first time we need to retrieve all releases/tags of its starred repos and it use a lot (really a lot) of rate limit.

Also:
- switch from Redis extension to Predis (to support RedisMock)
- use unreleased `php-http/cache-plugin` version 1.3.0 (because we can remove the `private` restriction to be able to cache response)
- the `SYMFONY_DEPRECATIONS_HELPER` is because of the previous point (which trigger an error because of a deprecated parameter (which I didn't use, anyway))
- using `ocramius/proxy-manager` to lazy load services which requires the Github/Client because we don't want the Github Client Discovery to be triggered when clearing cache.