### PR TITLE
Add processors for consumer

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -92,8 +92,8 @@ swarrot:
                 poll_interval: 500000
             middleware_stack:
                 - configurator: swarrot.processor.new_relic
-                   extras:
-                       new_relic_app_name: banditore
+                  extras:
+                      new_relic_app_name: banditore
                 - configurator: swarrot.processor.max_messages
                   extras:
                       max_messages: 5
@@ -107,8 +107,8 @@ swarrot:
                 requeue_on_error: false
             middleware_stack:
                 - configurator: swarrot.processor.new_relic
-                   extras:
-                       new_relic_app_name: banditore
+                  extras:
+                      new_relic_app_name: banditore
                 # stop workers after 50 messages to avoid eating too much memory
                 - configurator: swarrot.processor.max_messages
                   extras:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -90,8 +90,14 @@ swarrot:
             processor: banditore.consumer.sync_starred_repos
             extras:
                 poll_interval: 500000
-                requeue_on_error: false
             middleware_stack:
+                - configurator: swarrot.processor.new_relic
+                   extras:
+                       new_relic_app_name: banditore
+                - configurator: swarrot.processor.max_messages
+                  extras:
+                      max_messages: 5
+                - configurator: swarrot.processor.retry
                 - configurator: swarrot.processor.exception_catcher
                 - configurator: swarrot.processor.ack
         banditore.sync_versions:
@@ -100,6 +106,14 @@ swarrot:
                 poll_interval: 500000
                 requeue_on_error: false
             middleware_stack:
+                - configurator: swarrot.processor.new_relic
+                   extras:
+                       new_relic_app_name: banditore
+                # stop workers after 50 messages to avoid eating too much memory
+                - configurator: swarrot.processor.max_messages
+                  extras:
+                      max_messages: 50
+                - configurator: swarrot.processor.retry
                 - configurator: swarrot.processor.exception_catcher
                 - configurator: swarrot.processor.ack
     messages_types:


### PR DESCRIPTION
swarrot.processor.max_messages: will kill the worker after XX messages. It save a lot of memory by restarting them quite often and always avoid losing MySQL connection.

swarrot.processor.retry: will retry 3 times to publish the message if an error occurs

swarrot.processor.new_relic: to long consumer as background job (even if free tier doesn’t allow visualizing background jobs…)

Might fix https://github.com/j0k3r/banditore/issues/25 & https://github.com/j0k3r/banditore/issues/16