### PR TITLE
Avoid /rate_limit to generate error

### DIFF
--- a/src/AppBundle/Github/RateLimitTrait.php
+++ b/src/AppBundle/Github/RateLimitTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AppBundle\Github;
+
+use Github\Client;
+use Http\Client\Exception\HttpException;
+use Psr\Log\LoggerInterface;
+
+trait RateLimitTrait
+{
+    /**
+     * Retrieve rate limit for the given authenticated client.
+     * It's in a separate method to be able to catch error in case of glimpse on the Github side.
+     *
+     * @return false|int
+     */
+    private function getRateLimits(Client $client, LoggerInterface $logger)
+    {
+        try {
+            $rateLimit = $client->api('rate_limit')->getRateLimits();
+
+            return $rateLimit['resources']['core']['remaining'];
+        } catch (HttpException $e) {
+            $logger->error('RateLimit call goes bad.', ['exception' => $e]);
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Introduce `RateLimitTrait` to retrieve remaining calls for a given client and also catch an eventually error.

Fix https://github.com/j0k3r/banditore/issues/26