### PR TITLE
Avoid exception from client discovery

### DIFF
--- a/src/AppBundle/Consumer/SyncStarredRepos.php
+++ b/src/AppBundle/Consumer/SyncStarredRepos.php
@@ -33,7 +33,10 @@ class SyncStarredRepos implements ProcessorInterface
     private $repoRepository;
     private $client;
 
-    public function __construct(EntityManager $em, UserRepository $userRepository, StarRepository $starRepository, RepoRepository $repoRepository, Client $client, LoggerInterface $logger)
+    /**
+     * Client parameter isn't casted because it can be false when no available client were found by the Github Client Discovery.
+     */
+    public function __construct(EntityManager $em, UserRepository $userRepository, StarRepository $starRepository, RepoRepository $repoRepository, $client, LoggerInterface $logger)
     {
         $this->em = $em;
         $this->userRepository = $userRepository;
@@ -45,6 +48,13 @@ class SyncStarredRepos implements ProcessorInterface
 
     public function process(Message $message, array $options)
     {
+        // in case no client with safe RateLimit were found
+        if (false === $this->client) {
+            $this->logger->error('No client provided');
+
+            return;
+        }
+
         $data = json_decode($message->getBody(), true);
 
         $user = $this->userRepository->find($data['user_id']);

--- a/tests/AppBundle/Consumer/SyncVersionsTest.php
+++ b/tests/AppBundle/Consumer/SyncVersionsTest.php
@@ -725,22 +725,6 @@ class SyncVersionsTest extends WebTestCase
         $pubsubhubbub->expects($this->never())
             ->method('pingHub');
 
-        $responses = new MockHandler([
-            // rate_limit
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => 10]]])),
-            // rate_limit
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => 10]]])),
-        ]);
-
-        $clientHandler = HandlerStack::create($responses);
-        $guzzleClient = new Client([
-            'handler' => $clientHandler,
-        ]);
-
-        $httpClient = new Guzzle6Client($guzzleClient);
-        $httpBuilder = new Builder($httpClient);
-        $githubClient = new GithubClient($httpBuilder);
-
         $logger = new Logger('foo');
         $logHandler = new TestHandler();
         $logger->pushHandler($logHandler);


### PR DESCRIPTION
Return false when no client are available and a check on each consumer to be sure the client is defined.

Fix https://github.com/j0k3r/banditore/issues/38
But need updated after merging https://github.com/j0k3r/banditore/pull/48 (to apply same check on the client to `SyncStarredRepos` consumer)