### PR TITLE
Add pagination instead of 'show more'

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -20,6 +20,7 @@ class AppKernel extends Kernel
             new Ekino\Bundle\NewRelicBundle\EkinoNewRelicBundle(),
             new Swarrot\SwarrotBundle\SwarrotBundle(),
             new Sentry\SentryBundle\SentryBundle(),
+            new AshleyDawson\SimplePaginationBundle\AshleyDawsonSimplePaginationBundle(),
             new AppBundle\AppBundle(),
         ];
 

--- a/app/Resources/views/default/_pagination.html.twig
+++ b/app/Resources/views/default/_pagination.html.twig
@@ -1,0 +1,28 @@
+
+<div class="pagination">
+
+    {% if pagination.firstPageNumber and pagination.firstPageNumber != pagination.currentPageNumber %}
+        <a class="previous" href="{{ path(routeName, queryParameters | merge({(pageParameterName): pagination.firstPageNumber})) }}"><i class="fa fa-angle-double-left"></i></a>
+    {% endif %}
+
+    {% if pagination.previousPageNumber %}
+        <a class="previous" href="{{ path(routeName, queryParameters | merge({(pageParameterName): pagination.previousPageNumber})) }}"><i class="fa fa-angle-left"></i></a>
+    {% endif %}
+
+    {% for page in pagination.pages %}
+        {% if page == pagination.currentPageNumber %}
+            <strong>{{ page }}</strong>
+        {% else %}
+            <a href="{{ path(routeName, queryParameters | merge({(pageParameterName): page})) }}">{{ page }}</a>
+        {% endif %}
+    {% endfor %}
+
+    {% if pagination.nextPageNumber %}
+        <a class="next" href="{{ path(routeName, queryParameters | merge({(pageParameterName): pagination.nextPageNumber})) }}"><i class="fa fa-angle-right"></i></a>
+    {% endif %}
+
+    {% if pagination.lastPageNumber and pagination.lastPageNumber != pagination.currentPageNumber %}
+        <a class="next" href="{{ path(routeName, queryParameters | merge({(pageParameterName): pagination.lastPageNumber})) }}"><i class="fa fa-angle-double-right"></i></a>
+    {% endif %}
+
+</div>

--- a/app/Resources/views/default/dashboard.html.twig
+++ b/app/Resources/views/default/dashboard.html.twig
@@ -11,11 +11,20 @@
 
         <h2 class="content-head is-center">Your latest releases</h2>
 
-        {% if repos is empty %}
+        {% if pagination.items %}
+            {% if pagination.totalNumberOfPages > 1 %}
+                <p class="is-center">
+                    {{ simple_pagination_render(
+                        pagination,
+                        'dashboard',
+                        'page',
+                        app.request.query.all
+                    ) }}
+                </p>
+            {% endif %}
+        {% else %}
             <p><i>Here are some sample display.</i></p>
         {% endif %}
-
-        <input type="checkbox" class="read-more-state" id="read-more" />
 
         <table class="pure-table">
             <thead>
@@ -26,9 +35,9 @@
                 </tr>
             </thead>
 
-            <tbody class="read-more-wrap">
-                {% for repo in repos -%}
-                    <tr class="{% if loop.index is odd %}pure-table-odd{% endif %} {% if loop.index > 20 %}read-more-target{% endif %}">
+            <tbody>
+                {% for repo in pagination.items -%}
+                    <tr class="{% if loop.index is odd %}pure-table-odd{% endif %}">
                         <td data-th="Repo">
                             <img class="repo-avatar" src="{{ repo.ownerAvatar }}&amp;s=25"/>
                             <a href="https://github.com/{{ repo.fullName }}" title="{{ repo.description }}">{{ repo.fullName }}</a>
@@ -72,9 +81,14 @@
             </tbody>
         </table>
 
-        {% if repos|length > 20 %}
+        {% if pagination.items and pagination.totalNumberOfPages > 1 %}
             <p class="is-center">
-                <label for="read-more" class="read-more-trigger pure-button" data-more-items="{{ repos|length-20 }}"></label>
+                {{ simple_pagination_render(
+                    pagination,
+                    'dashboard',
+                    'page',
+                    app.request.query.all
+                ) }}
             </p>
         {% endif %}
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -134,3 +134,9 @@ ekino_new_relic:
     transaction_naming: route
     ignored_commands:
         - "cache:clear"
+
+ashley_dawson_simple_pagination:
+    defaults:
+        items_per_page: 30
+        pages_in_range: 5
+        template: default/_pagination.html.twig

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "doctrine/doctrine-migrations-bundle": "^1.2",
         "sentry/sentry-symfony": "^0.7.1",
         "ekino/newrelic-bundle": "^1.3",
-        "ocramius/proxy-manager": "^1.0"
+        "ocramius/proxy-manager": "^1.0",
+        "ashleydawson/simple-pagination-bundle": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,115 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd01bfab79908c4ef59d98fcb4fafd03",
+    "content-hash": "7accd3cfb235411449fa442a9d66b2d7",
     "packages": [
+        {
+            "name": "ashleydawson/simple-pagination",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/AshleyDawson/SimplePagination.git",
+                "reference": "a155be1e3338d41dec5aae840e2ec17e575e4b66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/AshleyDawson/SimplePagination/zipball/a155be1e3338d41dec5aae840e2ec17e575e4b66",
+                "reference": "a155be1e3338d41dec5aae840e2ec17e575e4b66",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "AshleyDawson\\SimplePagination\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ashley Dawson",
+                    "email": "ashley@ashleydawson.co.uk"
+                }
+            ],
+            "description": "Simple, lightweight and universal service that implements pagination on collections of things",
+            "keywords": [
+                "Flexible",
+                "Simple",
+                "easy",
+                "lightweight",
+                "lite",
+                "pager",
+                "pagination",
+                "paginator",
+                "universal"
+            ],
+            "time": "2015-05-20T18:16:52+00:00"
+        },
+        {
+            "name": "ashleydawson/simple-pagination-bundle",
+            "version": "1.0.3",
+            "target-dir": "AshleyDawson/SimplePaginationBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/AshleyDawson/SimplePaginationBundle.git",
+                "reference": "bcbbef4371a3874252897f6606cb0fe6f3c01f15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/AshleyDawson/SimplePaginationBundle/zipball/bcbbef4371a3874252897f6606cb0fe6f3c01f15",
+                "reference": "bcbbef4371a3874252897f6606cb0fe6f3c01f15",
+                "shasum": ""
+            },
+            "require": {
+                "ashleydawson/simple-pagination": "1.0.*",
+                "php": ">=5.3.3",
+                "symfony/symfony": "~2.3|~3.0"
+            },
+            "require-dev": {
+                "phpunit/php-code-coverage": "3.0.*@dev",
+                "phpunit/phpunit": "4.3.*@dev",
+                "phpunit/phpunit-mock-objects": "2.3.*@dev"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-0": {
+                    "AshleyDawson\\SimplePaginationBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ashley Dawson",
+                    "email": "ashley@ashleydawson.co.uk"
+                }
+            ],
+            "description": "Symfony2 bundle for Simple Pagination, the simple, lightweight and universal paginator that implements pagination on collections of things",
+            "keywords": [
+                "Flexible",
+                "Simple",
+                "Symfony2",
+                "bundle",
+                "easy",
+                "lightweight",
+                "lite",
+                "pager",
+                "pagination",
+                "paginator",
+                "universal"
+            ],
+            "time": "2016-11-25T15:02:04+00:00"
+        },
         {
             "name": "cache/adapter-common",
             "version": "0.3.3",

--- a/src/AppBundle/Repository/VersionRepository.php
+++ b/src/AppBundle/Repository/VersionRepository.php
@@ -32,27 +32,63 @@ class VersionRepository extends \Doctrine\ORM\EntityRepository
     }
 
     /**
+     * Retrieve latest version of each repo for a user_id with pagination.
+     *
+     * @param int $userId User ID
+     * @param int $offset
+     * @param int $length
+     *
+     * @return array
+     */
+    public function findLastVersionForEachRepoForUser($userId, $offset = 0, $length = 30)
+    {
+        $baseQuery = $this->getBaseQueryForLastVersionForEachRepoForUser($userId);
+
+        return $this->getEntityManager()->createQuery('
+                SELECT v1.tagName, v1.name, v1.createdAt, r.fullName, r.description, r.ownerAvatar, v1.prerelease
+                ' . $baseQuery
+            )
+            ->setFirstResult($offset)
+            ->setMaxResults($length)
+            ->setParameter('userId', $userId)
+            ->getArrayResult();
+    }
+
+    /**
+     * Return total lines for latest version of each repo for a user_id with pagination.
+     *
+     * @param int $userId User ID
+     *
+     * @return int
+     */
+    public function countLastVersionForEachRepoForUser($userId)
+    {
+        $baseQuery = $this->getBaseQueryForLastVersionForEachRepoForUser($userId);
+
+        return (int) $this->getEntityManager()->createQuery('
+                SELECT count(v1.id)
+                ' . $baseQuery
+            )
+            ->setParameter('userId', $userId)
+            ->getSingleScalarResult();
+    }
+
+    /**
      * DQL query to retrieve last version of each repo starred by a user.
      * We use DQL because it was to complex to use a query builder.
      *
      * @param int $userId User ID
      *
-     * @return array
+     * @return string
      */
-    public function findLastVersionForEachRepoForUser($userId)
+    private function getBaseQueryForLastVersionForEachRepoForUser($userId)
     {
-        $query = $this->getEntityManager()->createQuery("
-            SELECT v1.tagName, v1.name, v1.createdAt, r.fullName, r.description, r.ownerAvatar, v1.prerelease
-            FROM AppBundle\Entity\Version v1
+        return "FROM AppBundle\Entity\Version v1
             LEFT JOIN AppBundle\Entity\Version v2 WITH ( v1.repo = v2.repo AND v1.createdAt < v2.createdAt )
             LEFT JOIN AppBundle\Entity\Star s WITH s.repo = v1.repo
             LEFT JOIN AppBundle\Entity\Repo r WITH r.id = s.repo
             WHERE v2.repo IS NULL
             AND s.user = :userId
-            ORDER BY v1.createdAt DESC");
-
-        $query->setParameter('userId', $userId);
-
-        return $query->getArrayResult();
+            ORDER BY v1.createdAt DESC";
     }
 }

--- a/src/AppBundle/Repository/VersionRepository.php
+++ b/src/AppBundle/Repository/VersionRepository.php
@@ -42,12 +42,9 @@ class VersionRepository extends \Doctrine\ORM\EntityRepository
      */
     public function findLastVersionForEachRepoForUser($userId, $offset = 0, $length = 30)
     {
-        $baseQuery = $this->getBaseQueryForLastVersionForEachRepoForUser($userId);
+        $query = 'SELECT v1.tagName, v1.name, v1.createdAt, r.fullName, r.description, r.ownerAvatar, v1.prerelease ' . $this->getBaseQueryForLastVersionForEachRepoForUser();
 
-        return $this->getEntityManager()->createQuery('
-                SELECT v1.tagName, v1.name, v1.createdAt, r.fullName, r.description, r.ownerAvatar, v1.prerelease
-                ' . $baseQuery
-            )
+        return $this->getEntityManager()->createQuery($query)
             ->setFirstResult($offset)
             ->setMaxResults($length)
             ->setParameter('userId', $userId)
@@ -63,12 +60,9 @@ class VersionRepository extends \Doctrine\ORM\EntityRepository
      */
     public function countLastVersionForEachRepoForUser($userId)
     {
-        $baseQuery = $this->getBaseQueryForLastVersionForEachRepoForUser($userId);
+        $query = 'SELECT count(v1.id) ' . $this->getBaseQueryForLastVersionForEachRepoForUser();
 
-        return (int) $this->getEntityManager()->createQuery('
-                SELECT count(v1.id)
-                ' . $baseQuery
-            )
+        return (int) $this->getEntityManager()->createQuery($query)
             ->setParameter('userId', $userId)
             ->getSingleScalarResult();
     }
@@ -77,11 +71,9 @@ class VersionRepository extends \Doctrine\ORM\EntityRepository
      * DQL query to retrieve last version of each repo starred by a user.
      * We use DQL because it was to complex to use a query builder.
      *
-     * @param int $userId User ID
-     *
      * @return string
      */
-    private function getBaseQueryForLastVersionForEachRepoForUser($userId)
+    private function getBaseQueryForLastVersionForEachRepoForUser()
     {
         return "FROM AppBundle\Entity\Version v1
             LEFT JOIN AppBundle\Entity\Version v2 WITH ( v1.repo = v2.repo AND v1.createdAt < v2.createdAt )

--- a/tests/AppBundle/Controller/DefaultControllerTest.php
+++ b/tests/AppBundle/Controller/DefaultControllerTest.php
@@ -44,6 +44,17 @@ class DefaultControllerTest extends WebTestCase
         $this->assertContains('https://github.com/login/oauth/authorize?scope=user%2Crepo', $this->client->getResponse()->getTargetUrl());
     }
 
+    public function testConnectWithLoggedInUser()
+    {
+        $user = $this->client->getContainer()->get('banditore.repository.user')->find(123);
+
+        $this->logIn($user);
+        $this->client->request('GET', '/connect');
+
+        $this->assertSame(302, $this->client->getResponse()->getStatusCode());
+        $this->assertContains('dashboard', $this->client->getResponse()->getTargetUrl());
+    }
+
     public function testDashboardNotLoggedIn()
     {
         $this->client->request('GET', '/dashboard');
@@ -67,6 +78,27 @@ class DefaultControllerTest extends WebTestCase
 
         $table = $crawler->filter('table')->text();
         $this->assertContains('test/test', $table, 'Repo test/test exist in a table');
+    }
+
+    public function testDashboardPageTooHigh()
+    {
+        $user = $this->client->getContainer()->get('banditore.repository.user')->find(123);
+
+        $this->logIn($user);
+        $crawler = $this->client->request('GET', '/dashboard?page=20000');
+
+        $this->assertSame(302, $this->client->getResponse()->getStatusCode());
+        $this->assertContains('dashboard', $this->client->getResponse()->getTargetUrl());
+    }
+
+    public function testDashboardBadPage()
+    {
+        $user = $this->client->getContainer()->get('banditore.repository.user')->find(123);
+
+        $this->logIn($user);
+        $crawler = $this->client->request('GET', '/dashboard?page=dsdsds');
+
+        $this->assertSame(404, $this->client->getResponse()->getStatusCode());
     }
 
     public function testRss()

--- a/web/css/banditore.css
+++ b/web/css/banditore.css
@@ -283,29 +283,46 @@ img.repo-avatar {
 }
 
 /*
- * Read more "button"
+ * Pagination
  *
- * From https://codepen.io/Idered/pen/AeBgF?editors=1100
+ * From https://www.bypeople.com/quick-and-simple-pagination-cssdeck/
  */
-.read-more-state,
-.read-more-target {
+.pagination {
+    text-align: center;
+    margin: 20px
+}
+
+.pagination a.previous,
+.pagination a.next {
     display: none;
 }
 
-.read-more-state:checked ~ .pure-table .read-more-wrap .read-more-target {
-    display: table-row;
+.pagination a, .pagination strong {
+    color: #4A4A4A;
+    border: 0;
+    outline: 0;
+    background: #fff;
+    display: inline-block;
+    margin-right: 3px;
+    padding: 4px 12px;
+    text-decoration: none;
+    line-height: 1.5em;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+}
+.pagination a:hover {
+    background-color: #10556B;
+    color: #fff;
 }
 
-.read-more-state ~ .is-center .read-more-trigger:before {
-    content: 'Show more (' attr(data-more-items) ')';
+.pagination a:active {
+    background: rgba(190, 190, 190, 0.75);
 }
 
-.read-more-state:checked ~ .is-center .read-more-trigger:before {
-    content: 'Show less';
-}
-
-.read-more-trigger {
-    cursor: pointer;
+.pagination strong {
+    color: #fff;
+    background-color: #FFAB80;
 }
 
 /*
@@ -395,8 +412,7 @@ img.repo-avatar {
         font-size: 16px;
     }
 
-    /* We can align the menu header to the left, but float the
-    menu items to the right. */
+    /* We can align the menu header to the left, but float the menu items to the right. */
     .home-menu {
         text-align: left;
     }
@@ -440,6 +456,11 @@ img.repo-avatar {
     .pure-table th, .pure-table td {
         display: table-cell;
         border-left: 1px solid #cbcbcb;
+    }
+
+    .pagination a.previous,
+    .pagination a.next {
+        display: inline-block;
     }
 }
 


### PR DESCRIPTION
When user has a lot of releases the dashboard html page is huge and can take several seconds to display.
Using a pagination the dom is smaller so the page loads faster.