### PR TITLE
Do not inject EntityManager

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -97,6 +97,7 @@ swarrot:
                 - configurator: swarrot.processor.max_messages
                   extras:
                       max_messages: 5
+                - configurator: swarrot.processor.doctrine_connection
                 - configurator: swarrot.processor.retry
                 - configurator: swarrot.processor.exception_catcher
                 - configurator: swarrot.processor.ack
@@ -113,6 +114,7 @@ swarrot:
                 - configurator: swarrot.processor.max_messages
                   extras:
                       max_messages: 50
+                - configurator: swarrot.processor.doctrine_connection
                 - configurator: swarrot.processor.retry
                 - configurator: swarrot.processor.exception_catcher
                 - configurator: swarrot.processor.ack

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -90,7 +90,7 @@ services:
     banditore.consumer.sync_starred_repos:
         class: AppBundle\Consumer\SyncStarredRepos
         arguments:
-            - "@doctrine.orm.default_entity_manager"
+            - "@doctrine"
             - "@banditore.repository.user"
             - "@banditore.repository.star"
             - "@banditore.repository.repo"
@@ -103,7 +103,7 @@ services:
     banditore.consumer.sync_versions:
         class: AppBundle\Consumer\SyncVersions
         arguments:
-            - "@doctrine.orm.default_entity_manager"
+            - "@doctrine"
             - "@banditore.repository.repo"
             - "@banditore.repository.version"
             - "@banditore.pubsubhubbub.publisher"

--- a/tests/AppBundle/Consumer/SyncStarredReposTest.php
+++ b/tests/AppBundle/Consumer/SyncStarredReposTest.php
@@ -21,7 +21,7 @@ class SyncStarredReposTest extends WebTestCase
 {
     public function testProcessNoUser()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -50,7 +50,7 @@ class SyncStarredReposTest extends WebTestCase
             ->method('authenticate');
 
         $processor = new SyncStarredRepos(
-            $em,
+            $doctrine,
             $userRepository,
             $starRepository,
             $repoRepository,
@@ -66,6 +66,13 @@ class SyncStarredReposTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getManager')
+            ->willReturn($em);
 
         $user = new User();
         $user->setId(123);
@@ -134,7 +141,7 @@ class SyncStarredReposTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncStarredRepos(
-            $em,
+            $doctrine,
             $userRepository,
             $starRepository,
             $repoRepository,
@@ -157,6 +164,13 @@ class SyncStarredReposTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getManager')
+            ->willReturn($em);
 
         $user = new User();
         $user->setId(123);
@@ -223,7 +237,7 @@ class SyncStarredReposTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncStarredRepos(
-            $em,
+            $doctrine,
             $userRepository,
             $starRepository,
             $repoRepository,
@@ -248,6 +262,13 @@ class SyncStarredReposTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getManager')
+            ->willReturn($em);
 
         $user = new User();
         $user->setId(123);
@@ -312,7 +333,7 @@ class SyncStarredReposTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncStarredRepos(
-            $em,
+            $doctrine,
             $userRepository,
             $starRepository,
             $repoRepository,
@@ -331,7 +352,7 @@ class SyncStarredReposTest extends WebTestCase
 
     public function testProcessWithBadClient()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -361,7 +382,7 @@ class SyncStarredReposTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncStarredRepos(
-            $em,
+            $doctrine,
             $userRepository,
             $starRepository,
             $repoRepository,

--- a/tests/AppBundle/Consumer/SyncVersionsTest.php
+++ b/tests/AppBundle/Consumer/SyncVersionsTest.php
@@ -22,7 +22,7 @@ class SyncVersionsTest extends WebTestCase
 {
     public function testProcessNoRepo()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -51,7 +51,7 @@ class SyncVersionsTest extends WebTestCase
             ->method('authenticate');
 
         $processor = new SyncVersions(
-            $em,
+            $doctrine,
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
@@ -197,6 +197,13 @@ class SyncVersionsTest extends WebTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getManager')
+            ->willReturn($em);
+
         $repo = new Repo();
         $repo->setId(123);
         $repo->setFullName('bob/wow');
@@ -246,7 +253,7 @@ class SyncVersionsTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncVersions(
-            $em,
+            $doctrine,
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
@@ -271,6 +278,13 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getManager')
+            ->willReturn($em);
 
         $repo = new Repo();
         $repo->setId(123);
@@ -320,7 +334,7 @@ class SyncVersionsTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncVersions(
-            $em,
+            $doctrine,
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
@@ -345,6 +359,13 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getManager')
+            ->willReturn($em);
 
         $repo = new Repo();
         $repo->setId(123);
@@ -428,7 +449,7 @@ class SyncVersionsTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncVersions(
-            $em,
+            $doctrine,
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
@@ -453,6 +474,13 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getManager')
+            ->willReturn($em);
 
         $repo = new Repo();
         $repo->setId(123);
@@ -502,7 +530,7 @@ class SyncVersionsTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncVersions(
-            $em,
+            $doctrine,
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
@@ -527,6 +555,13 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getManager')
+            ->willReturn($em);
 
         $repo = new Repo();
         $repo->setId(123);
@@ -600,7 +635,7 @@ class SyncVersionsTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncVersions(
-            $em,
+            $doctrine,
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
@@ -625,6 +660,13 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getManager')
+            ->willReturn($em);
 
         $repo = new Repo();
         $repo->setId(123);
@@ -684,7 +726,7 @@ class SyncVersionsTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncVersions(
-            $em,
+            $doctrine,
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
@@ -703,7 +745,7 @@ class SyncVersionsTest extends WebTestCase
 
     public function testProcessWithBadClient()
     {
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+        $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -730,7 +772,7 @@ class SyncVersionsTest extends WebTestCase
         $logger->pushHandler($logHandler);
 
         $processor = new SyncVersions(
-            $em,
+            $doctrine,
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
@@ -764,6 +806,15 @@ class SyncVersionsTest extends WebTestCase
 
         // override factory to avoid real call to Github
         $container->set('banditore.client.github', $githubClient);
+
+        $guzzleClientPub = $this->getMockBuilder('GuzzleHttp\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $guzzleClientPub->expects($this->once())
+            ->method('__call') // post
+            ->willReturn(new Response(204));
+
+        $container->set('banditore.client.guzzle', $guzzleClientPub);
 
         $processor = $container->get('banditore.consumer.sync_versions');
 


### PR DESCRIPTION
But retrieves it when needed to avoid error when is goes closed (in case of error).
Might fix https://github.com/j0k3r/banditore/issues/40