### PR TITLE
Fix case insensitive error for some tag 

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -105,7 +105,6 @@ swarrot:
             processor: banditore.consumer.sync_versions
             extras:
                 poll_interval: 500000
-                requeue_on_error: false
             middleware_stack:
                 - configurator: swarrot.processor.new_relic
                   extras:

--- a/composer.lock
+++ b/composer.lock
@@ -2126,16 +2126,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.9",
+            "version": "v2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "6968531206671f94377b01dc7888d5d1b858a01b"
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/6968531206671f94377b01dc7888d5d1b858a01b",
-                "reference": "6968531206671f94377b01dc7888d5d1b858a01b",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
                 "shasum": ""
             },
             "require": {
@@ -2170,7 +2170,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-03T20:43:42+00:00"
+            "time": "2017-03-13T16:27:32+00:00"
         },
         {
             "name": "php-amqplib/php-amqplib",
@@ -4264,16 +4264,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.1.1",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "e0e33ce4eaf59ba77ead9ce45256692aa29ecb38"
+                "reference": "c7de769d7b44f2c9de68e1f678b65efd8126f60b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/e0e33ce4eaf59ba77ead9ce45256692aa29ecb38",
-                "reference": "e0e33ce4eaf59ba77ead9ce45256692aa29ecb38",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/c7de769d7b44f2c9de68e1f678b65efd8126f60b",
+                "reference": "c7de769d7b44f2c9de68e1f678b65efd8126f60b",
                 "shasum": ""
             },
             "require": {
@@ -4296,7 +4296,7 @@
             "require-dev": {
                 "gecko-packages/gecko-php-unit": "^2.0",
                 "justinrainbow/json-schema": "^5.0",
-                "phpunit/phpunit": "^4.5|^5",
+                "phpunit/phpunit": "^4.5 || ^5.0",
                 "satooshi/php-coveralls": "^1.0",
                 "symfony/phpunit-bridge": "^3.2"
             },
@@ -4327,7 +4327,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2017-03-03T08:03:57+00:00"
+            "time": "2017-03-15T17:13:07+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -4535,16 +4535,16 @@
         },
         {
             "name": "sensio/generator-bundle",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioGeneratorBundle.git",
-                "reference": "c76c7833ed5ffe0f5aeef15e13939ddb59a684eb"
+                "reference": "37f9f4e165b033fb76cc2320838321cc57140e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/c76c7833ed5ffe0f5aeef15e13939ddb59a684eb",
-                "reference": "c76c7833ed5ffe0f5aeef15e13939ddb59a684eb",
+                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/37f9f4e165b033fb76cc2320838321cc57140e65",
+                "reference": "37f9f4e165b033fb76cc2320838321cc57140e65",
                 "shasum": ""
             },
             "require": {
@@ -4556,7 +4556,9 @@
             },
             "require-dev": {
                 "doctrine/orm": "~2.4",
-                "symfony/doctrine-bridge": "~2.7|~3.0"
+                "symfony/doctrine-bridge": "~2.7|~3.0",
+                "symfony/filesystem": "~2.7|~3.0",
+                "symfony/phpunit-bridge": "^3.3"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -4583,7 +4585,7 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "time": "2017-03-03T15:22:50+00:00"
+            "time": "2017-03-15T01:02:10+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",

--- a/src/AppBundle/Consumer/SyncStarredRepos.php
+++ b/src/AppBundle/Consumer/SyncStarredRepos.php
@@ -91,6 +91,11 @@ class SyncStarredRepos implements ProcessorInterface
         $starredRepos = $this->client->api('user')->starred($user->getUsername(), $page, $perPage);
         $em = $this->doctrine->getManager();
 
+        // in case of the manager is closed following a previous exception
+        if (!$em->isOpen()) {
+            $em = $this->doctrine->resetManager();
+        }
+
         do {
             $this->logger->info('    sync ' . count($starredRepos) . ' starred repos', [
                 'user' => $user->getUsername(),

--- a/src/AppBundle/Consumer/SyncVersions.php
+++ b/src/AppBundle/Consumer/SyncVersions.php
@@ -64,13 +64,8 @@ class SyncVersions implements ProcessorInterface
 
         $this->logger->notice('[' . $this->getRateLimits($this->client, $this->logger) . '] Check <info>' . $repo->getFullName() . '</info> … ');
 
-        try {
-            $nbVersions = $this->doSyncVersions($repo);
-        } catch (\Exception $e) {
-            $this->logger->error('Error while syncing repo', ['exception' => get_class($e), 'message' => $e->getMessage(), 'repo' => $repo->getFullName()]);
-
-            return;
-        }
+        // this shouldn't be catched so the worker will die when an exception is thrown
+        $nbVersions = $this->doSyncVersions($repo);
 
         // notify pubsubhubbub for that repo
         if ($nbVersions > 0) {
@@ -126,6 +121,16 @@ class SyncVersions implements ProcessorInterface
 
             if (null !== $version) {
                 continue;
+            }
+
+            // check for scheduled version to be persisted later
+            // in rare case where the tag name is almost equal, like "v1.1.0" & "V1.1.0" in might avoid error
+            foreach ($em->getUnitOfWork()->getScheduledEntityInsertions() as $entity) {
+                if ($entity instanceof Version && strtolower($entity->getTagName()) === strtolower($tag['name'])) {
+                    $this->logger->info($tag['name'] . ' skipped because it seems to be already scheduled');
+
+                    continue 2;
+                }
             }
 
             // is there an associated release?

--- a/src/AppBundle/Consumer/SyncVersions.php
+++ b/src/AppBundle/Consumer/SyncVersions.php
@@ -85,6 +85,11 @@ class SyncVersions implements ProcessorInterface
         $newVersion = 0;
         $em = $this->doctrine->getManager();
 
+        // in case of the manager is closed following a previous exception
+        if (!$em->isOpen()) {
+            $em = $this->doctrine->resetManager();
+        }
+
         list($username, $repoName) = explode('/', $repo->getFullName());
 
         // this is a simple call to retrieve at least one tag from the selected repo

--- a/src/AppBundle/DataFixtures/ORM/LoadVersionData.php
+++ b/src/AppBundle/DataFixtures/ORM/LoadVersionData.php
@@ -19,11 +19,22 @@ class LoadVersionData extends AbstractFixture implements OrderedFixtureInterface
             'message' => 'YAY',
             'published_at' => (date('Y') + 1) . '-10-15T07:49:21Z',
         ]);
-
         $manager->persist($version1);
+
+        $version2 = new Version($this->getReference('repo2'));
+        $version2->hydrateFromGithub([
+            'tag_name' => '1.0.21',
+            'name' => 'First release',
+            'prerelease' => false,
+            'message' => 'YAY 555',
+            'published_at' => (date('Y') + 1) . '-06-15T07:49:21Z',
+        ]);
+
+        $manager->persist($version2);
         $manager->flush();
 
         $this->addReference('version1', $version1);
+        $this->addReference('version2', $version2);
     }
 
     /**

--- a/tests/AppBundle/Consumer/SyncStarredReposTest.php
+++ b/tests/AppBundle/Consumer/SyncStarredReposTest.php
@@ -66,6 +66,9 @@ class SyncStarredReposTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(true);
 
         $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
@@ -164,6 +167,9 @@ class SyncStarredReposTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(true);
 
         $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
@@ -262,12 +268,18 @@ class SyncStarredReposTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(false); // simulate a closing manager
 
         $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
             ->getMock();
         $doctrine->expects($this->once())
             ->method('getManager')
+            ->willReturn($em);
+        $doctrine->expects($this->once())
+            ->method('resetManager')
             ->willReturn($em);
 
         $user = new User();

--- a/tests/AppBundle/Consumer/SyncVersionsTest.php
+++ b/tests/AppBundle/Consumer/SyncVersionsTest.php
@@ -203,6 +203,9 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(false); // simulate a closing manager
         $em->expects($this->exactly(3))
             ->method('getUnitOfWork')
             ->willReturn($uow);
@@ -212,6 +215,9 @@ class SyncVersionsTest extends WebTestCase
             ->getMock();
         $doctrine->expects($this->once())
             ->method('getManager')
+            ->willReturn($em);
+        $doctrine->expects($this->once())
+            ->method('resetManager')
             ->willReturn($em);
 
         $repo = new Repo();
@@ -288,6 +294,9 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(true);
 
         $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
@@ -376,6 +385,9 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(true);
         $em->expects($this->once())
             ->method('getUnitOfWork')
             ->willReturn($uow);
@@ -494,6 +506,9 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(true);
 
         $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
@@ -578,6 +593,9 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(true);
 
         $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
@@ -673,6 +691,9 @@ class SyncVersionsTest extends WebTestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->once())
+            ->method('isOpen')
+            ->willReturn(true);
 
         $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()

--- a/tests/AppBundle/Consumer/SyncVersionsTest.php
+++ b/tests/AppBundle/Consumer/SyncVersionsTest.php
@@ -193,9 +193,19 @@ class SyncVersionsTest extends WebTestCase
 
     public function testProcessSuccessfulMessage()
     {
+        $uow = $this->getMockBuilder('Doctrine\ORM\UnitOfWork')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $uow->expects($this->exactly(3))
+            ->method('getScheduledEntityInsertions')
+            ->willReturn([]);
+
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->exactly(3))
+            ->method('getUnitOfWork')
+            ->willReturn($uow);
 
         $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
@@ -356,9 +366,19 @@ class SyncVersionsTest extends WebTestCase
      */
     public function testProcessMarkdownFailed()
     {
+        $uow = $this->getMockBuilder('Doctrine\ORM\UnitOfWork')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $uow->expects($this->once())
+            ->method('getScheduledEntityInsertions')
+            ->willReturn([]);
+
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
+        $em->expects($this->once())
+            ->method('getUnitOfWork')
+            ->willReturn($uow);
 
         $doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
             ->disableOriginalConstructor()
@@ -549,6 +569,9 @@ class SyncVersionsTest extends WebTestCase
 
     /**
      * Generate an unexpected error (like from MySQL).
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage booboo
      */
     public function testProcessUnexpectedError()
     {
@@ -630,26 +653,16 @@ class SyncVersionsTest extends WebTestCase
         $httpBuilder = new Builder($httpClient);
         $githubClient = new GithubClient($httpBuilder);
 
-        $logger = new Logger('foo');
-        $logHandler = new TestHandler();
-        $logger->pushHandler($logHandler);
-
         $processor = new SyncVersions(
             $doctrine,
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
             $githubClient,
-            $logger
+            new NullLogger()
         );
 
         $processor->process(new Message(json_encode(['repo_id' => 123])), []);
-
-        $records = $logHandler->getRecords();
-
-        $this->assertSame('Consume banditore.sync_versions message', $records[0]['message']);
-        $this->assertSame('[10] Check <info>bob/wow</info> … ', $records[1]['message']);
-        $this->assertSame('Error while syncing repo', $records[2]['message']);
     }
 
     /**
@@ -788,7 +801,7 @@ class SyncVersionsTest extends WebTestCase
     }
 
     /**
-     * Using only mocks for request.
+     * Using mocks only for request.
      */
     public function testFunctionalConsumer()
     {
@@ -825,11 +838,97 @@ class SyncVersionsTest extends WebTestCase
         $processor->process(new Message(json_encode(['repo_id' => 666])), []);
 
         $versions = $container->get('banditore.repository.version')->findBy(['repo' => 666]);
-        $this->assertCount(4, $versions, 'Repo 666 has now 3 versions');
+        $this->assertCount(4, $versions, 'Repo 666 has now 4 versions');
         $this->assertSame('1.0.0', $versions[0]->getTagName(), 'Repo 666 has 4 version. First one is 1.0.0');
         $this->assertSame('1.0.1', $versions[1]->getTagName(), 'Repo 666 has 4 version. Second one is 1.0.1');
         $this->assertSame('1.0.2', $versions[2]->getTagName(), 'Repo 666 has 4 version. Third one is 1.0.2');
         $this->assertSame('<p>weekly release</p>', $versions[2]->getBody(), 'Version 1.0.2 does NOT have a PGP signature');
         $this->assertSame('2.0.1', $versions[3]->getTagName(), 'Repo 666 has 4 version. Fourth one is 2.0.1');
+    }
+
+    public function testFunctionalConsumerWithTagCaseInsensitive()
+    {
+        $responses = new MockHandler([
+            // rate_limit
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => 10]]])),
+            // repo/tags
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([[
+                'name' => 'v2.11.0',
+                'zipball_url' => 'https://api.github.com/repos/mozilla/metrics-graphics/zipball/v2.11.0',
+                'tarball_url' => 'https://api.github.com/repos/mozilla/metrics-graphics/tarball/v2.11.0',
+            ]])),
+            // git/refs/tags
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                [
+                    'ref' => 'refs/tags/V1.1.0',
+                    'url' => 'https://api.github.com/repos/mozilla/metrics-graphics/git/refs/tags/V1.1.0',
+                    'object' => [
+                        'sha' => '6402716c3165eb90cdace5729a18706ea2921187',
+                        'type' => 'commit',
+                        'url' => 'https://api.github.com/repos/mozilla/metrics-graphics/git/commits/6402716c3165eb90cdace5729a18706ea2921187',
+                    ],
+                ],
+                [
+                    'ref' => 'refs/tags/v1.1.0',
+                    'url' => 'https://api.github.com/repos/mozilla/metrics-graphics/git/refs/tags/v1.1.0',
+                    'object' => [
+                        'sha' => '15a4703db568342043f156b5635d10b17ebe98cb',
+                        'type' => 'commit',
+                        'url' => 'https://api.github.com/repos/mozilla/metrics-graphics/git/commits/15a4703db568342043f156b5635d10b17ebe98cb',
+                    ],
+                ],
+            ])),
+            // TAG V1.1.0
+            // now tag V1.1.0 which is a release
+            new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                'tag_name' => 'V1.1.0',
+                'name' => 'V1.1.0',
+                'prerelease' => false,
+                'published_at' => '2014-12-01T18:28:39Z',
+                'body' => 'This is the first release after our major push.',
+            ])),
+            // markdown
+            new Response(200, ['Content-Type' => 'text/html'], '<p>This is the first release after our major push.</p>'),
+            // rate_limit
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => 10]]])),
+        ]);
+
+        $clientHandler = HandlerStack::create($responses);
+        $guzzleClient = new Client([
+            'handler' => $clientHandler,
+        ]);
+
+        $httpClient = new Guzzle6Client($guzzleClient);
+        $httpBuilder = new Builder($httpClient);
+        $githubClient = new GithubClient($httpBuilder);
+
+        $client = static::createClient();
+        $container = $client->getContainer();
+
+        // override factory to avoid real call to Github
+        $container->set('banditore.client.github', $githubClient);
+
+        $guzzleClientPub = $this->getMockBuilder('GuzzleHttp\Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $guzzleClientPub->expects($this->once())
+            ->method('__call') // post
+            ->willReturn(new Response(204));
+
+        $container->set('banditore.client.guzzle', $guzzleClientPub);
+
+        $processor = $container->get('banditore.consumer.sync_versions');
+
+        $versions = $container->get('banditore.repository.version')->findBy(['repo' => 555]);
+        $this->assertCount(1, $versions, 'Repo 555 has 1 version');
+        $this->assertSame('1.0.21', $versions[0]->getTagName(), 'Repo 555 has 1 version, which is 1.0.21');
+
+        $processor->process(new Message(json_encode(['repo_id' => 555])), []);
+
+        $versions = $container->get('banditore.repository.version')->findBy(['repo' => 555]);
+        $this->assertCount(2, $versions, 'Repo 555 has now 2 versions');
+        $this->assertSame('1.0.21', $versions[0]->getTagName(), 'Repo 555 has 2 version. First one is 1.0.21');
+        $this->assertSame('V1.1.0', $versions[1]->getTagName(), 'Repo 555 has 2 version. Second one is V1.1.0');
+        $this->assertSame('<p>This is the first release after our major push.</p>', $versions[1]->getBody(), 'Version V1.1.0 body is ok');
     }
 }


### PR DESCRIPTION
For example when there are two tags:
- V1.0.0
- v1.0.0

utf8mb4 from MySQL is case insensitive, so the unique index will fail after the first insertion. To avoid that I check "to be persisted" entities before validating a new one.

Also, https://github.com/j0k3r/banditore/issues/40 should be fixed for good now.