### PR TITLE
Stop processing messages when rate limit is reached

### DIFF
--- a/src/AppBundle/Consumer/SyncStarredRepos.php
+++ b/src/AppBundle/Consumer/SyncStarredRepos.php
@@ -52,7 +52,7 @@ class SyncStarredRepos implements ProcessorInterface
         if (false === $this->client) {
             $this->logger->error('No client provided');
 
-            return;
+            return false;
         }
 
         $data = json_decode($message->getBody(), true);
@@ -67,13 +67,8 @@ class SyncStarredRepos implements ProcessorInterface
 
         $this->logger->notice('Consume banditore.sync_starred_repos message', ['user' => $user->getUsername()]);
 
-        try {
-            $nbRepos = $this->doSyncRepo($user);
-        } catch (\Exception $e) {
-            $this->logger->error('Error while syncing starred repos', ['exception' => $e->getMessage(), 'user' => $user->getUsername()]);
-
-            return;
-        }
+        // this shouldn't be catched so the worker will die when an exception is thrown
+        $nbRepos = $this->doSyncRepo($user);
 
         $this->logger->notice('Synced repos: ' . $nbRepos, ['user' => $user->getUsername()]);
     }

--- a/tests/AppBundle/Consumer/SyncStarredReposTest.php
+++ b/tests/AppBundle/Consumer/SyncStarredReposTest.php
@@ -162,6 +162,10 @@ class SyncStarredReposTest extends WebTestCase
         $this->assertSame('Synced repos: 1', $records[3]['message']);
     }
 
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage booboo
+     */
     public function testProcessUnexpectedError()
     {
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
@@ -238,26 +242,16 @@ class SyncStarredReposTest extends WebTestCase
 
         $githubClient = $this->getMockClient($responses);
 
-        $logger = new Logger('foo');
-        $logHandler = new TestHandler();
-        $logger->pushHandler($logHandler);
-
         $processor = new SyncStarredRepos(
             $doctrine,
             $userRepository,
             $starRepository,
             $repoRepository,
             $githubClient,
-            $logger
+            new NullLogger()
         );
 
         $processor->process(new Message(json_encode(['user_id' => 123])), []);
-
-        $records = $logHandler->getRecords();
-
-        $this->assertSame('Consume banditore.sync_starred_repos message', $records[0]['message']);
-        $this->assertSame('    sync 1 starred repos', $records[1]['message']);
-        $this->assertSame('Error while syncing starred repos', $records[2]['message']);
     }
 
     /**


### PR DESCRIPTION
Avoid have too much message handled for nothing:

```
[2017-03-16 11:53:59] app.NOTICE: Consume banditore.sync_versions message {"repo":"bdunogier/MediapartProxy"}
[2017-03-16 11:53:59] app.NOTICE: [0] Check bdunogier/MediapartProxy …
[2017-03-16 11:53:59] app.WARNING: (repo/tags) You have reached GitHub hourly limit! Actual limit is: 5000
[2017-03-16 11:53:59] app.NOTICE: [0]  new versions for bdunogier/MediapartProxy
[2017-03-16 11:53:59] app.NOTICE: Consume banditore.sync_versions message {"repo":"Squirrel/Squirrel.Windows"}
[2017-03-16 11:53:59] app.NOTICE: [0] Check Squirrel/Squirrel.Windows …
[2017-03-16 11:53:59] app.WARNING: (repo/tags) You have reached GitHub hourly limit! Actual limit is: 5000
[2017-03-16 11:53:59] app.NOTICE: [0]  new versions for Squirrel/Squirrel.Windows
[2017-03-16 11:53:59] app.NOTICE: Consume banditore.sync_versions message {"repo":"jshackles/idle_master"}
[2017-03-16 11:54:00] app.NOTICE: [0] Check jshackles/idle_master …
[2017-03-16 11:54:00] app.WARNING: (repo/tags) You have reached GitHub hourly limit! Actual limit is: 5000
[2017-03-16 11:54:00] app.NOTICE: [0]  new versions for jshackles/idle_master
[2017-03-16 11:54:00] app.NOTICE: Consume banditore.sync_versions message {"repo":"amzn/amazon-payments-magento-plugin"}
[2017-03-16 11:54:00] app.NOTICE: [0] Check amzn/amazon-payments-magento-plugin …
[2017-03-16 11:54:00] app.WARNING: (repo/tags) You have reached GitHub hourly limit! Actual limit is: 5000
```