### PR TITLE
Fix star sync

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "sensio/framework-extra-bundle": "^3.0.2",
         "sentry/sentry-symfony": "^0.7.1",
         "snc/redis-bundle": "^2.0",
-        "swarrot/swarrot-bundle": "dev-master",
+        "swarrot/swarrot-bundle": "^1.4.2",
         "symfony/monolog-bundle": "^3.0.2",
         "symfony/polyfill-apcu": "^1.0",
         "symfony/symfony": "3.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2036b573ab3be3bfd98555933625bd6",
+    "content-hash": "636ee7a2c01de95bf6a7f653f0cc1c35",
     "packages": [
         {
             "name": "ashleydawson/simple-pagination",
@@ -3391,16 +3391,16 @@
         },
         {
             "name": "swarrot/swarrot-bundle",
-            "version": "dev-master",
+            "version": "v1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swarrot/SwarrotBundle.git",
-                "reference": "3bc08801ae23b0cdb2d36cd4d083164afecb3ecd"
+                "reference": "84c7c57622e4666ae5706f33cd71842639b78755"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swarrot/SwarrotBundle/zipball/3bc08801ae23b0cdb2d36cd4d083164afecb3ecd",
-                "reference": "3bc08801ae23b0cdb2d36cd4d083164afecb3ecd",
+                "url": "https://api.github.com/repos/swarrot/SwarrotBundle/zipball/84c7c57622e4666ae5706f33cd71842639b78755",
+                "reference": "84c7c57622e4666ae5706f33cd71842639b78755",
                 "shasum": ""
             },
             "require": {
@@ -3446,7 +3446,7 @@
                 "bundle",
                 "swarrot"
             ],
-            "time": "2017-03-18 15:42:54"
+            "time": "2017-03-20T15:57:40+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -4892,7 +4892,6 @@
     "stability-flags": {
         "knplabs/github-api": 20,
         "php-http/cache-plugin": 20,
-        "swarrot/swarrot-bundle": 20,
         "satooshi/php-coveralls": 20,
         "m6web/redis-mock": 20
     },

--- a/src/AppBundle/Consumer/SyncStarredRepos.php
+++ b/src/AppBundle/Consumer/SyncStarredRepos.php
@@ -123,9 +123,9 @@ class SyncStarredRepos implements ProcessorInterface
 
                     $em->persist($star);
                 }
-
-                $em->flush();
             }
+
+            $em->flush();
 
             $starredRepos = $this->client->api('user')->starred($user->getUsername(), ++$page, $perPage);
         } while (!empty($starredRepos));

--- a/src/AppBundle/Repository/StarRepository.php
+++ b/src/AppBundle/Repository/StarRepository.php
@@ -20,7 +20,7 @@ class StarRepository extends \Doctrine\ORM\EntityRepository
     public function findAllByUser($userId)
     {
         $repos = $this->createQueryBuilder('s')
-            ->select('r.fullName')
+            ->select('r.id')
             ->leftJoin('s.repo', 'r')
             ->where('s.user = ' . $userId)
             ->getQuery()
@@ -28,7 +28,7 @@ class StarRepository extends \Doctrine\ORM\EntityRepository
 
         $res = [];
         foreach ($repos as $repo) {
-            $res[] = $repo['fullName'];
+            $res[] = $repo['id'];
         }
 
         return $res;
@@ -37,16 +37,16 @@ class StarRepository extends \Doctrine\ORM\EntityRepository
     /**
      * Remove stars for a user.
      *
-     * @param array $starIds
+     * @param array $repoIds
      * @param int   $userId
      *
      * @return mixed
      */
-    public function removeFromUser(array $starIds, $userId)
+    public function removeFromUser(array $repoIds, $userId)
     {
         return $this->createQueryBuilder('s')
             ->delete()
-            ->where('s.repo IN (:ids)')->setParameter('ids', $starIds)
+            ->where('s.repo IN (:ids)')->setParameter('ids', $repoIds)
             ->andWhere('s.user = :userId')->setParameter('userId', $userId)
             ->getQuery()
             ->execute();


### PR DESCRIPTION
Star sync was based on repo `full_name`
But this value can change during the sync (for example when a repo change its name) so it become inaccurate.