### PR TITLE
Re-check rate limit for starred repo

### DIFF
--- a/src/AppBundle/Consumer/SyncStarredRepos.php
+++ b/src/AppBundle/Consumer/SyncStarredRepos.php
@@ -69,6 +69,16 @@ class SyncStarredRepos implements ProcessorInterface
 
         $this->logger->notice('Consume banditore.sync_starred_repos message', ['user' => $user->getUsername()]);
 
+        $rateLimit = $this->getRateLimits($this->client, $this->logger);
+
+        $this->logger->notice('[' . $rateLimit . '] Check <info>' . $user->getUsername() . '</info> … ');
+
+        if (0 === $rateLimit || false === $rateLimit) {
+            $this->logger->warning('RateLimit reached, stopping.');
+
+            return false;
+        }
+
         // this shouldn't be catched so the worker will die when an exception is thrown
         $nbRepos = $this->doSyncRepo($user);
 


### PR DESCRIPTION
Like it was done for the version sync, check that rate limit is ok.
Since the worker will handle XX messages before quiting, the given Github client might have already reached its limit when the message will be processed and then result in that error:

> [2017-03-29 11:45:02] app.ERROR: [Ack] An exception occurred. Message #2 has been nack'ed. {"swarrot_processor":"ack","exception":"[object] (Github\\Exception\\ApiLimitExceedException(code: 0): You have reached GitHub hourly limit! Actual limit is: 5000 at /www/vendor/knplabs/github-api/lib/Github/HttpClient/Plugin/GithubExceptionThrower.php:37)"}