### PR TITLE
Flush more often to avoid losing version

### DIFF
--- a/src/AppBundle/Consumer/SyncVersions.php
+++ b/src/AppBundle/Consumer/SyncVersions.php
@@ -200,6 +200,11 @@ class SyncVersions implements ProcessorInterface
             $em->persist($version);
 
             ++$newVersion;
+
+            // for big repos, flush every 200 versions in case of hitting rate limit
+            if (($newVersion % 200) === 0) {
+                $em->flush();
+            }
         }
 
         $em->flush();


### PR DESCRIPTION
On really big repos like vim/vim (5k releases!) we need to flush more often than just after fetching all release.
With 5k release, we can’t fetch all of them in one time (because rate limit is 5k). So it must be done in at least 2 pass. And avoid losing no flushed version between each call, we need to flush more often.