### PR TITLE
Rise rate limit thresold for user

### DIFF
--- a/src/AppBundle/Github/ClientDiscovery.php
+++ b/src/AppBundle/Github/ClientDiscovery.php
@@ -18,7 +18,8 @@ class ClientDiscovery
 {
     use RateLimitTrait;
 
-    const THRESHOLD_BAD_AUTH = 50;
+    const THRESHOLD_RATE_REMAIN_APP = 200;
+    const THRESHOLD_RATE_REMAIN_USER = 2000;
 
     private $userRepository;
     private $redis;
@@ -74,7 +75,7 @@ class ClientDiscovery
         $this->client->authenticate($this->clientId, $this->clientSecret, GithubClient::AUTH_URL_CLIENT_ID);
 
         $remaining = $this->getRateLimits($this->client, $this->logger);
-        if ($remaining >= self::THRESHOLD_BAD_AUTH) {
+        if ($remaining >= self::THRESHOLD_RATE_REMAIN_APP) {
             $this->logger->notice('RateLimit ok (' . $remaining . ') with default application');
 
             return $this->client;
@@ -87,7 +88,7 @@ class ClientDiscovery
             $this->client->authenticate($user['accessToken'], null, GithubClient::AUTH_HTTP_TOKEN);
 
             $remaining = $this->getRateLimits($this->client, $this->logger);
-            if ($remaining >= self::THRESHOLD_BAD_AUTH) {
+            if ($remaining >= self::THRESHOLD_RATE_REMAIN_USER) {
                 $this->logger->notice('RateLimit ok (' . $remaining . ') with user: ' . $user['username']);
 
                 return $this->client;

--- a/tests/AppBundle/Github/ClientDiscoveryTest.php
+++ b/tests/AppBundle/Github/ClientDiscoveryTest.php
@@ -25,7 +25,7 @@ class ClientDiscoveryTest extends WebTestCase
 
         $responses = new MockHandler([
             // first rate_limit, it'll be ok because remaining > 50
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH + 1]]])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_RATE_REMAIN_APP + 1]]])),
         ]);
 
         $clientHandler = HandlerStack::create($responses);
@@ -57,7 +57,7 @@ class ClientDiscoveryTest extends WebTestCase
         $records = $logHandler->getRecords();
 
         $this->assertInstanceOf('Github\Client', $resClient);
-        $this->assertSame('RateLimit ok (' . (ClientDiscovery::THRESHOLD_BAD_AUTH + 1) . ') with default application', $records[0]['message']);
+        $this->assertSame('RateLimit ok (' . (ClientDiscovery::THRESHOLD_RATE_REMAIN_APP + 1) . ') with default application', $records[0]['message']);
     }
 
     public function testUseUserToken()
@@ -83,11 +83,11 @@ class ClientDiscoveryTest extends WebTestCase
 
         $responses = new MockHandler([
             // first rate_limit, it won't be ok because remaining < 50
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH - 40]]])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_RATE_REMAIN_APP - 40]]])),
             // second rate_limit, it won't be ok because remaining < 50
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH - 20]]])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_RATE_REMAIN_USER - 20]]])),
             // third rate_limit, it'll' be ok because remaining > 50
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH + 150]]])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_RATE_REMAIN_USER + 150]]])),
         ]);
 
         $clientHandler = HandlerStack::create($responses);
@@ -119,7 +119,7 @@ class ClientDiscoveryTest extends WebTestCase
         $records = $logHandler->getRecords();
 
         $this->assertInstanceOf('Github\Client', $resClient);
-        $this->assertSame('RateLimit ok (' . (ClientDiscovery::THRESHOLD_BAD_AUTH + 150) . ') with user: lion', $records[0]['message']);
+        $this->assertSame('RateLimit ok (' . (ClientDiscovery::THRESHOLD_RATE_REMAIN_USER + 150) . ') with user: lion', $records[0]['message']);
     }
 
     public function testNoTokenAvailable()
@@ -140,9 +140,9 @@ class ClientDiscoveryTest extends WebTestCase
 
         $responses = new MockHandler([
             // first rate_limit, it won't be ok because remaining < 50
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH - 10]]])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_RATE_REMAIN_APP - 10]]])),
             // second rate_limit, it won't be ok because remaining < 50
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH - 20]]])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_RATE_REMAIN_APP - 20]]])),
         ]);
 
         $clientHandler = HandlerStack::create($responses);
@@ -196,9 +196,9 @@ class ClientDiscoveryTest extends WebTestCase
 
         $responses = new MockHandler([
             // first rate_limit request fail (Github booboo)
-            new Response(400, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH + 100]]])),
+            new Response(400, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_RATE_REMAIN_USER + 100]]])),
             // second rate_limit, it'll be ok because remaining > 50
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH + 100]]])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_RATE_REMAIN_USER + 100]]])),
         ]);
 
         $clientHandler = HandlerStack::create($responses);
@@ -231,7 +231,7 @@ class ClientDiscoveryTest extends WebTestCase
 
         $this->assertInstanceOf('Github\Client', $resClient);
         $this->assertSame('RateLimit call goes bad.', $records[0]['message']);
-        $this->assertSame('RateLimit ok (' . (ClientDiscovery::THRESHOLD_BAD_AUTH + 100) . ') with user: bob', $records[1]['message']);
+        $this->assertSame('RateLimit ok (' . (ClientDiscovery::THRESHOLD_RATE_REMAIN_USER + 100) . ') with user: bob', $records[1]['message']);
     }
 
     /**
@@ -244,9 +244,9 @@ class ClientDiscoveryTest extends WebTestCase
 
         $responses = new MockHandler([
             // first rate_limit request fail (Github booboo)
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH - 10]]])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_RATE_REMAIN_APP - 10]]])),
             // second rate_limit, it'll be ok because remaining > 50
-            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_BAD_AUTH + 100]]])),
+            new Response(200, ['Content-Type' => 'application/json'], json_encode(['resources' => ['core' => ['remaining' => ClientDiscovery::THRESHOLD_RATE_REMAIN_USER + 100]]])),
         ]);
 
         $clientHandler = HandlerStack::create($responses);


### PR DESCRIPTION
User token is global to all app. We MUST avoid consoming all of it.
So instead of a low thresold, rise it to let user to other stuff with its Github.
Also, rise the application one to avoid error when fetching new version.