### PR TITLE
We don’t need scopes for public data

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -89,8 +89,7 @@ class DefaultController extends Controller
 
         return $this->get('oauth2.registry')
             ->getClient('github')
-            // scopes requested
-            ->redirect(['user', 'repo']);
+            ->redirect();
     }
 
     /**

--- a/tests/AppBundle/Controller/DefaultControllerTest.php
+++ b/tests/AppBundle/Controller/DefaultControllerTest.php
@@ -41,7 +41,7 @@ class DefaultControllerTest extends WebTestCase
         $this->client->request('GET', '/connect');
 
         $this->assertSame(302, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('https://github.com/login/oauth/authorize?scope=user%2Crepo', $this->client->getResponse()->getTargetUrl());
+        $this->assertContains('https://github.com/login/oauth/authorize?', $this->client->getResponse()->getTargetUrl());
     }
 
     public function testConnectWithLoggedInUser()


### PR DESCRIPTION
Starred repositories & user information are public so we don’t need to request custom scope.

Fix https://github.com/j0k3r/banditore/issues/73 & Fix https://github.com/j0k3r/banditore/issues/71