### PR TITLE
Improve queries

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -127,8 +127,8 @@ class DefaultController extends Controller
                 'avgReleasePerRepo' => ($nbRepos > 0) ? round($nbReleases / $nbRepos, 2) : 0,
                 'avgStarPerUser' => ($nbUsers > 0) ? round($nbStars / $nbUsers, 2) : 0,
             ],
-            'mostReleases' => $this->get('banditore.repository.version')->mostVersionsPerRepo(),
-            'lastestReleases' => $this->get('banditore.repository.version')->findLastVersionForEachRepo(),
+            'mostReleases' => $this->get('banditore.repository.repo')->mostVersionsPerRepo(),
+            'lastestReleases' => $this->get('banditore.repository.version')->findLastVersionForEachRepo(20),
         ]);
     }
 }

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -40,12 +40,12 @@ class DefaultController extends Controller
 
         // Pass the item total
         $paginator->setItemTotalCallback(function () use ($repoVersion, $userId) {
-            return $repoVersion->countLastVersionForEachRepoForUser($userId);
+            return $repoVersion->countForUser($userId);
         });
 
         // Pass the slice
         $paginator->setSliceCallback(function ($offset, $length) use ($repoVersion, $userId) {
-            return $repoVersion->findLastVersionForEachRepoForUser($userId, $offset, $length);
+            return $repoVersion->findForUser($userId, $offset, $length);
         });
 
         // Paginate using the current page number

--- a/src/AppBundle/Repository/RepoRepository.php
+++ b/src/AppBundle/Repository/RepoRepository.php
@@ -42,4 +42,25 @@ class RepoRepository extends \Doctrine\ORM\EntityRepository
             ->getQuery()
             ->getSingleScalarResult();
     }
+
+    /**
+     * Retrieve repos with the most releases.
+     * Used for stats.
+     *
+     * @return array
+     */
+    public function mostVersionsPerRepo()
+    {
+        return $this->createQueryBuilder('r')
+            ->select('r.fullName', 'r.description', 'r.ownerAvatar')
+            ->addSelect('(SELECT COUNT(v.id)
+                FROM AppBundle\Entity\Version v
+                WHERE v.repo = r.id) AS total'
+            )
+            ->groupBy('r.fullName', 'r.description', 'r.ownerAvatar')
+            ->orderBy('total', 'desc')
+            ->setMaxResults(5)
+            ->getQuery()
+            ->getArrayResult();
+    }
 }

--- a/src/AppBundle/Repository/VersionRepository.php
+++ b/src/AppBundle/Repository/VersionRepository.php
@@ -39,58 +39,41 @@ class VersionRepository extends \Doctrine\ORM\EntityRepository
 
     /**
      * Find all versions available for the given user.
-     * They'll be put in a RSS feed.
      *
      * @param int $userId
      *
      * @return array
      */
-    public function findForUser($userId)
+    public function findForUser($userId, $offset = 0, $length = 20)
     {
         return $this->createQueryBuilder('v')
-            ->select('v.tagName', 'v.createdAt', 'v.body', 'r.fullName', 'r.ownerAvatar', 'r.ownerAvatar', 'r.homepage', 'r.language', 'r.description')
+            ->select('v.tagName', 'v.name', 'v.createdAt', 'v.body', 'v.prerelease', 'r.fullName', 'r.ownerAvatar', 'r.ownerAvatar', 'r.homepage', 'r.language', 'r.description')
             ->leftJoin('v.repo', 'r')
             ->leftJoin('r.stars', 's')
             ->where('s.user = :userId')->setParameter('userId', $userId)
             ->orderBy('v.createdAt', 'desc')
-            ->setMaxResults(20)
+            ->setFirstResult($offset)
+            ->setMaxResults($length)
             ->getQuery()
             ->getArrayResult();
     }
 
     /**
-     * Retrieve latest version of each repo for a user_id with pagination.
+     * Count all versions available for the given user.
+     * Used in the dashboard pagination.
      *
-     * @param int $userId User ID
-     * @param int $offset
-     * @param int $length
+     * @param int $userId
      *
      * @return array
      */
-    public function findLastVersionForEachRepoForUser($userId, $offset = 0, $length = 30)
+    public function countForUser($userId)
     {
-        $query = 'SELECT v1.tagName, v1.name, v1.createdAt, r.fullName, r.description, r.ownerAvatar, v1.prerelease ' . $this->getBaseQueryForLastVersionForEachRepoForUser();
-
-        return $this->getEntityManager()->createQuery($query)
-            ->setFirstResult($offset)
-            ->setMaxResults($length)
-            ->setParameter('userId', $userId)
-            ->getArrayResult();
-    }
-
-    /**
-     * Return total lines for latest version of each repo for a user_id with pagination.
-     *
-     * @param int $userId User ID
-     *
-     * @return int
-     */
-    public function countLastVersionForEachRepoForUser($userId)
-    {
-        $query = 'SELECT count(v1.id) ' . $this->getBaseQueryForLastVersionForEachRepoForUser();
-
-        return (int) $this->getEntityManager()->createQuery($query)
-            ->setParameter('userId', $userId)
+        return $this->createQueryBuilder('v')
+            ->select('COUNT(v.id)')
+            ->leftJoin('v.repo', 'r')
+            ->leftJoin('r.stars', 's')
+            ->where('s.user = :userId')->setParameter('userId', $userId)
+            ->getQuery()
             ->getSingleScalarResult();
     }
 
@@ -129,22 +112,5 @@ class VersionRepository extends \Doctrine\ORM\EntityRepository
             ->select('COUNT(v.id) as total')
             ->getQuery()
             ->getSingleScalarResult();
-    }
-
-    /**
-     * DQL query to retrieve last version of each repo starred by a user (or globally).
-     * We use DQL because it was to complex to use a query builder.
-     *
-     * @return string
-     */
-    private function getBaseQueryForLastVersionForEachRepoForUser()
-    {
-        return 'FROM AppBundle\Entity\Version v1
-            LEFT JOIN AppBundle\Entity\Version v2 WITH (v1.repo = v2.repo AND v1.createdAt < v2.createdAt)
-            LEFT JOIN AppBundle\Entity\Star s WITH s.repo = v1.repo
-            LEFT JOIN AppBundle\Entity\Repo r WITH r.id = s.repo
-            WHERE v2.repo IS NULL
-            AND s.user = :userId
-            ORDER BY v1.createdAt DESC';
     }
 }

--- a/src/AppBundle/Repository/VersionRepository.php
+++ b/src/AppBundle/Repository/VersionRepository.php
@@ -41,6 +41,8 @@ class VersionRepository extends \Doctrine\ORM\EntityRepository
      * Find all versions available for the given user.
      *
      * @param int $userId
+     * @param int $offset
+     * @param int $length
      *
      * @return array
      */

--- a/src/AppBundle/Repository/VersionRepository.php
+++ b/src/AppBundle/Repository/VersionRepository.php
@@ -132,24 +132,6 @@ class VersionRepository extends \Doctrine\ORM\EntityRepository
     }
 
     /**
-     * Retrieve repos with the most releases.
-     * Used for stats.
-     *
-     * @return array
-     */
-    public function mostVersionsPerRepo()
-    {
-        return $this->createQueryBuilder('v')
-            ->select('r.fullName', 'r.description', 'r.ownerAvatar', 'count(v.id) as total')
-            ->leftJoin('v.repo', 'r')
-            ->groupBy('r.fullName', 'r.description', 'r.ownerAvatar')
-            ->orderBy('total', 'desc')
-            ->setMaxResults(5)
-            ->getQuery()
-            ->getArrayResult();
-    }
-
-    /**
      * DQL query to retrieve last version of each repo starred by a user (or globally).
      * We use DQL because it was to complex to use a query builder.
      *

--- a/src/AppBundle/Security/GithubAuthenticator.php
+++ b/src/AppBundle/Security/GithubAuthenticator.php
@@ -73,7 +73,7 @@ class GithubAuthenticator extends SocialAuthenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
     {
-        $versions = $this->em->getRepository('AppBundle:Version')->findLastVersionForEachRepoForUser($token->getUser()->getId());
+        $versions = $this->em->getRepository('AppBundle:Version')->findForUser($token->getUser()->getId());
 
         // if no versions were found, it means the user logged in for the first time
         // and we need to display an explanation message


### PR DESCRIPTION
**Improve SQL query for stats page**
Use a better query to retrieve repositories with the most releases.

⚡️  Goes from 3s to 100ms. 💨 

**Use same query for RSS & dashboard**
Instead of grouping repo to display only the latest release on the dashboard, use the same query for the RSS which will display all latest releases non-grouping per repo.
This speedup the query and the dashboard display.

⚡️ Goes from 2s to 55ms. 💨 