### PR TITLE
Add more autowire services

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ Banditore retrieves new releases from your GitHub starred repositories and put t
 5. Setup the database
 
     ```bash
-    php bin/console doctrine:database:create -e=prod
-    php bin/console doctrine:schema:create -e=prod
+    php bin/console doctrine:database:create -e prod
+    php bin/console doctrine:schema:create -e prod
     ```
 
 4. You can now launch the website:
 
     ```bash
-    php bin/console server:run -e=prod
+    php bin/console server:run -e prod
     ```
 
     And access it at this address: `http://127.0.0.1:8000`
@@ -66,9 +66,9 @@ You just need to define these 2 cronjobs (replace all `/path/to/banditore` with 
 
 ```bash
 # retrieve new release of each repo every 10 minutes
-*/10  *   *   *   *   php /path/to/banditore/bin/console -e=prod banditore:sync:versions >> /path/to/banditore/var/logs/command-sync-versions.log 2>&1
+*/10  *   *   *   *   php /path/to/banditore/bin/console -e prod banditore:sync:versions >> /path/to/banditore/var/logs/command-sync-versions.log 2>&1
 # sync starred repos of each user every 5 minutes
-*/5   *   *   *   *   php /path/to/banditore/bin/console -e=prod banditore:sync:starred-repos >> /path/banditore/to/var/logs/command-sync-repos.log 2>&1
+*/5   *   *   *   *   php /path/to/banditore/bin/console -e prod banditore:sync:starred-repos >> /path/banditore/to/var/logs/command-sync-repos.log 2>&1
 ```
 
 ### With RabbitMQ
@@ -87,9 +87,9 @@ You just need to define these 2 cronjobs (replace all `/path/to/banditore` with 
 
  ```bash
  # retrieve new release of each repo every 10 minutes
- */10  *   *   *   *   php /path/to/banditore/bin/console -e=prod banditore:sync:versions --use-queue >> /path/to/banditore/var/logs/command-sync-versions.log 2>&1
+ */10  *   *   *   *   php /path/to/banditore/bin/console -e prod banditore:sync:versions --use_queue >> /path/to/banditore/var/logs/command-sync-versions.log 2>&1
  # sync starred repos of each user every 5 minutes
- */5   *   *   *   *   php /path/to/banditore/bin/console -e=prod banditore:sync:starred-repos --use-queue >> /path/banditore/to/var/logs/command-sync-repos.log 2>&1
+ */5   *   *   *   *   php /path/to/banditore/bin/console -e prod banditore:sync:starred-repos --use_queue >> /path/banditore/to/var/logs/command-sync-repos.log 2>&1
 ```
 
 4. Setup Supervisor using the [sample file](data/supervisor.conf) from the repo. You can copy/paste it into `/etc/supervisor/conf.d/` and adjust path. The default file will launch:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -86,7 +86,7 @@ swarrot:
             vhost: '/'
     consumers:
         banditore.sync_starred_repos:
-            processor: banditore.consumer.sync_starred_repos
+            processor: AppBundle\Consumer\SyncStarredRepos
             extras:
                 poll_interval: 500000
             middleware_stack:
@@ -101,7 +101,7 @@ swarrot:
                 - configurator: swarrot.processor.exception_catcher
                 - configurator: swarrot.processor.ack
         banditore.sync_versions:
-            processor: banditore.consumer.sync_versions
+            processor: AppBundle\Consumer\SyncVersions
             extras:
                 poll_interval: 500000
             middleware_stack:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -7,12 +7,37 @@ services:
     # autowire
     AppBundle\:
         resource: '../../src/AppBundle/*'
-        exclude: '../../src/AppBundle/{Entity,Consumer,DataFixtures,PubSubHubbub}'
+        exclude: '../../src/AppBundle/{Entity,DataFixtures}'
 
     AppBundle\Controller\:
         resource: '../../src/AppBundle/Controller'
         public: true
         tags: ['controller.service_arguments']
+
+    # autorwire parameters
+    AppBundle\Github\ClientDiscovery:
+        arguments:
+            $clientId: "%github_client_id%"
+            $clientSecret: "%github_client_secret%"
+
+    AppBundle\PubSubHubbub\Publisher:
+        arguments:
+            $hub: "http://pubsubhubbub.appspot.com"
+            $host: "%project_host%"
+            $scheme: "%project_scheme%"
+
+    AppBundle\Webfeeds\WebfeedsWriter:
+        tags:
+            - { name: marcw_rss_writer.extension.writer }
+
+    # lazy consumer
+    # to avoid triggering Github Client Discovery
+    # which will make a doctrine query on Travis because the default limit to Github will be reached
+    AppBundle\Consumer\SyncStarredRepos:
+        lazy: true
+
+    AppBundle\Consumer\SyncVersions:
+        lazy: true
 
     # github stuff
     banditore.client.guzzle:
@@ -20,30 +45,16 @@ services:
 
     banditore.client.github:
         class: Github\Client
-        factory: [ "@banditore.github.client_discovery", find ]
-
-    banditore.github.client_discovery:
-        class: AppBundle\Github\ClientDiscovery
-        arguments:
-            - "@AppBundle\\Repository\\UserRepository"
-            - "@snc_redis.guzzle_cache"
-            - "%github_client_id%"
-            - "%github_client_secret%"
-            - "@logger"
+        factory: [ "@AppBundle\\Github\\ClientDiscovery", find ]
 
     # feed stuff
-    banditore.writer.webfeeds:
-        class: AppBundle\Webfeeds\WebfeedsWriter
-        tags:
-            - { name: marcw_rss_writer.extension.writer }
-
     banditore.writer.rss:
         class: MarcW\RssWriter\RssWriter
         arguments:
             - ~
             -
                 core: "@marcw_rss_writer.writer.core"
-                webfeeds: "@banditore.writer.webfeeds"
+                webfeeds: "@AppBundle\\Webfeeds\\WebfeedsWriter"
                 atom: "@marcw_rss_writer.writer.atom"
             - true
             - "    "
@@ -51,65 +62,26 @@ services:
     # force this service to be injected at first instead of the default one (from marcw)
     MarcW\RssWriter\RssWriter: '@banditore.writer.rss'
 
-    banditore.pubsubhubbub.publisher:
-        class: AppBundle\PubSubHubbub\Publisher
-        arguments:
-            - "http://pubsubhubbub.appspot.com"
-            - "@router"
-            - "@banditore.client.guzzle"
-            - "@AppBundle\\Repository\\UserRepository"
-            - "%project_host%"
-            - "%project_scheme%"
-
-    banditore.rss.generator:
-        class: AppBundle\Rss\Generator
-
-    # consumers
-    banditore.consumer.sync_starred_repos:
-        class: AppBundle\Consumer\SyncStarredRepos
-        arguments:
-            - "@doctrine"
-            - "@AppBundle\\Repository\\UserRepository"
-            - "@AppBundle\\Repository\\StarRepository"
-            - "@AppBundle\\Repository\\RepoRepository"
-            - "@banditore.client.github"
-            - "@logger"
-        # to avoid triggering Github Client Discovery
-        # which will make a doctrine query on Travis because the default limit to Github will be reached
-        lazy: true
-
-    banditore.consumer.sync_versions:
-        class: AppBundle\Consumer\SyncVersions
-        arguments:
-            - "@doctrine"
-            - "@AppBundle\\Repository\\RepoRepository"
-            - "@AppBundle\\Repository\\VersionRepository"
-            - "@banditore.pubsubhubbub.publisher"
-            - "@banditore.client.github"
-            - "@logger"
-        # to avoid triggering Github Client Discovery
-        # which will make a doctrine query on Travis because the default limit to Github will be reached
-        lazy: true
-
     twig.extension.date:
         class: Twig_Extensions_Extension_Date
         tags:
             - { name: twig.extension }
 
-    # fucked alias I don't know why we must create them
-    # duplicate works of defining services ...
-    # Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "servicename" service to "classname" instead.
+    # alias to service from their class name
     Swarrot\SwarrotBundle\Broker\AmqpLibFactory:
         alias: swarrot.factory.amqp_lib
 
-    AppBundle\Consumer\SyncStarredRepos:
-        alias: banditore.consumer.sync_starred_repos
-
-    AppBundle\Consumer\SyncVersions:
-        alias: banditore.consumer.sync_versions
-
     Swarrot\SwarrotBundle\Broker\Publisher:
         alias: swarrot.publisher
+
+    Predis\Client:
+        alias: snc_redis.guzzle_cache
+
+    GuzzleHttp\Client:
+        alias: banditore.client.guzzle
+
+    Github\Client:
+        alias: banditore.client.github
 
     # force public because the bundle isn't up to date
     ashley_dawson_simple_pagination.paginator_public:

--- a/app/config/services_test.yml
+++ b/app/config/services_test.yml
@@ -23,15 +23,15 @@ services:
         public: true
 
     banditore.consumer.sync_versions.test:
-        alias: banditore.consumer.sync_versions
+        alias: AppBundle\Consumer\SyncVersions
         public: true
 
     banditore.consumer.sync_starred_repos.test:
-        alias: banditore.consumer.sync_starred_repos
+        alias: AppBundle\Consumer\SyncStarredRepos
         public: true
 
     banditore.github.client_discovery.test:
-        alias: banditore.github.client_discovery
+        alias: AppBundle\Github\ClientDiscovery
         public: true
 
     banditore.client.guzzle.test:

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "c34231f0f88662d8a6b4e9291cbc34ea",
@@ -2607,16 +2607,16 @@
         },
         {
             "name": "php-amqplib/php-amqplib",
-            "version": "v2.7.2",
+            "version": "v2.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-amqplib/php-amqplib.git",
-                "reference": "dfd3694a86f1a7394d3693485259d4074a6ec79b"
+                "reference": "a8ba54bd35b973fc6861e4c2e105f71e9e95f43f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/dfd3694a86f1a7394d3693485259d4074a6ec79b",
-                "reference": "dfd3694a86f1a7394d3693485259d4074a6ec79b",
+                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/a8ba54bd35b973fc6861e4c2e105f71e9e95f43f",
+                "reference": "a8ba54bd35b973fc6861e4c2e105f71e9e95f43f",
                 "shasum": ""
             },
             "require": {
@@ -2674,7 +2674,7 @@
                 "queue",
                 "rabbitmq"
             ],
-            "time": "2018-02-11T19:28:00+00:00"
+            "time": "2018-04-30T03:54:54+00:00"
         },
         {
             "name": "php-http/cache-plugin",
@@ -2734,16 +2734,16 @@
         },
         {
             "name": "php-http/client-common",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/client-common.git",
-                "reference": "949ee8a8cba5fa2abe839c87bf7b885ac3330589"
+                "reference": "0b9ce659aa46aee106f8c66597ea0c070fcd9dff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/client-common/zipball/949ee8a8cba5fa2abe839c87bf7b885ac3330589",
-                "reference": "949ee8a8cba5fa2abe839c87bf7b885ac3330589",
+                "url": "https://api.github.com/repos/php-http/client-common/zipball/0b9ce659aa46aee106f8c66597ea0c070fcd9dff",
+                "reference": "0b9ce659aa46aee106f8c66597ea0c070fcd9dff",
                 "shasum": ""
             },
             "require": {
@@ -2791,7 +2791,7 @@
                 "http",
                 "httplug"
             ],
-            "time": "2018-06-22T12:36:17+00:00"
+            "time": "2018-10-09T06:46:29+00:00"
         },
         {
             "name": "php-http/discovery",

--- a/data/supervisor.conf
+++ b/data/supervisor.conf
@@ -3,7 +3,7 @@ programs=sync_repo_1,sync_repo_2
 
 [program:sync_repo_1]
 directory=/path/to/banditore
-command=/usr/bin/php bin/console swarrot:consume:banditore.sync_starred_repos -e=prod banditore.sync_starred_repos
+command=/usr/bin/php bin/console swarrot:consume:banditore.sync_starred_repos -e prod banditore.sync_starred_repos
 autostart=true
 autorestart=true
 stderr_logfile=/space/logs/supervisord/sync_starred_repos_1.err
@@ -13,7 +13,7 @@ environment = http_proxy="",https_proxy=""
 
 [program:sync_repo_2]
 directory=/path/to/banditore
-command=/usr/bin/php bin/console swarrot:consume:banditore.sync_starred_repos -e=prod banditore.sync_starred_repos
+command=/usr/bin/php bin/console swarrot:consume:banditore.sync_starred_repos -e prod banditore.sync_starred_repos
 autostart=true
 autorestart=true
 stderr_logfile=/space/logs/supervisord/sync_starred_repos_2.err
@@ -26,7 +26,7 @@ programs=sync_version_1,sync_version_2,sync_version_3,sync_version_4
 
 [program:sync_version_1]
 directory=/path/to/banditore
-command=/usr/bin/php bin/console swarrot:consume:banditore.sync_versions -e=prod banditore.sync_versions
+command=/usr/bin/php bin/console swarrot:consume:banditore.sync_versions -e prod banditore.sync_versions
 autostart=true
 autorestart=true
 stderr_logfile=/space/logs/supervisord/sync_versions_1.err
@@ -36,7 +36,7 @@ environment = http_proxy="",https_proxy=""
 
 [program:sync_version_2]
 directory=/path/to/banditore
-command=/usr/bin/php bin/console swarrot:consume:banditore.sync_versions -e=prod banditore.sync_versions
+command=/usr/bin/php bin/console swarrot:consume:banditore.sync_versions -e prod banditore.sync_versions
 autostart=true
 autorestart=true
 stderr_logfile=/space/logs/supervisord/sync_versions_2.err
@@ -46,7 +46,7 @@ environment = http_proxy="",https_proxy=""
 
 [program:sync_version_3]
 directory=/path/to/banditore
-command=/usr/bin/php bin/console swarrot:consume:banditore.sync_versions -e=prod banditore.sync_versions
+command=/usr/bin/php bin/console swarrot:consume:banditore.sync_versions -e prod banditore.sync_versions
 autostart=true
 autorestart=true
 stderr_logfile=/space/logs/supervisord/sync_versions_3.err
@@ -56,7 +56,7 @@ environment = http_proxy="",https_proxy=""
 
 [program:sync_version_4]
 directory=/path/to/banditore
-command=/usr/bin/php bin/console swarrot:consume:banditore.sync_versions -e=prod banditore.sync_versions
+command=/usr/bin/php bin/console swarrot:consume:banditore.sync_versions -e prod banditore.sync_versions
 autostart=true
 autorestart=true
 stderr_logfile=/space/logs/supervisord/sync_versions_4.err

--- a/src/AppBundle/Consumer/SyncStarredRepos.php
+++ b/src/AppBundle/Consumer/SyncStarredRepos.php
@@ -9,11 +9,11 @@ use AppBundle\Github\RateLimitTrait;
 use AppBundle\Repository\RepoRepository;
 use AppBundle\Repository\StarRepository;
 use AppBundle\Repository\UserRepository;
-use Doctrine\Bundle\DoctrineBundle\Registry;
 use Github\Client;
 use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ProcessorInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * Consumer message to sync starred repos from user.
@@ -36,9 +36,9 @@ class SyncStarredRepos implements ProcessorInterface
     private $client;
 
     /**
-     * Client parameter isn't casted because it can be false when no available client were found by the Github Client Discovery.
+     * Client parameter can be null when no available client were found by the Github Client Discovery.
      */
-    public function __construct(Registry $doctrine, UserRepository $userRepository, StarRepository $starRepository, RepoRepository $repoRepository, $client, LoggerInterface $logger)
+    public function __construct(RegistryInterface $doctrine, UserRepository $userRepository, StarRepository $starRepository, RepoRepository $repoRepository, Client $client = null, LoggerInterface $logger)
     {
         $this->doctrine = $doctrine;
         $this->userRepository = $userRepository;
@@ -51,7 +51,7 @@ class SyncStarredRepos implements ProcessorInterface
     public function process(Message $message, array $options)
     {
         // in case no client with safe RateLimit were found
-        if (false === $this->client) {
+        if (null === $this->client) {
             $this->logger->error('No client provided');
 
             return false;

--- a/src/AppBundle/Consumer/SyncVersions.php
+++ b/src/AppBundle/Consumer/SyncVersions.php
@@ -8,11 +8,11 @@ use AppBundle\Github\RateLimitTrait;
 use AppBundle\PubSubHubbub\Publisher;
 use AppBundle\Repository\RepoRepository;
 use AppBundle\Repository\VersionRepository;
-use Doctrine\Bundle\DoctrineBundle\Registry;
 use Github\Client;
 use Psr\Log\LoggerInterface;
 use Swarrot\Broker\Message;
 use Swarrot\Processor\ProcessorInterface;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 
 /**
  * Consumer message to sync user repo (usually happen after a successful login).
@@ -29,9 +29,9 @@ class SyncVersions implements ProcessorInterface
     private $client;
 
     /**
-     * Client parameter isn't casted because it can be false when no available client were found by the Github Client Discovery.
+     * Client parameter can be null when no available client were found by the Github Client Discovery.
      */
-    public function __construct(Registry $doctrine, RepoRepository $repoRepository, VersionRepository $versionRepository, Publisher $pubsubhubbub, $client, LoggerInterface $logger)
+    public function __construct(RegistryInterface $doctrine, RepoRepository $repoRepository, VersionRepository $versionRepository, Publisher $pubsubhubbub, Client $client = null, LoggerInterface $logger)
     {
         $this->doctrine = $doctrine;
         $this->repoRepository = $repoRepository;
@@ -44,7 +44,7 @@ class SyncVersions implements ProcessorInterface
     public function process(Message $message, array $options)
     {
         // in case no client with safe RateLimit were found
-        if (false === $this->client) {
+        if (null === $this->client) {
             $this->logger->error('No client provided');
 
             return false;

--- a/src/AppBundle/Github/ClientDiscovery.php
+++ b/src/AppBundle/Github/ClientDiscovery.php
@@ -56,7 +56,7 @@ class ClientDiscovery
      *     - if the rate limit is too low for the application client, loop on all user to check their rate limit
      *     - if none client have enough rate limit, we'll have a problem to perform further request, stop every thing !
      *
-     * @return GithubClient|false
+     * @return GithubClient|null
      */
     public function find()
     {
@@ -96,7 +96,5 @@ class ClientDiscovery
         }
 
         $this->logger->warning('No way to authenticate a client with enough rate limit remaining :(');
-
-        return false;
     }
 }

--- a/src/AppBundle/PubSubHubbub/Publisher.php
+++ b/src/AppBundle/PubSubHubbub/Publisher.php
@@ -4,8 +4,8 @@ namespace AppBundle\PubSubHubbub;
 
 use AppBundle\Repository\UserRepository;
 use GuzzleHttp\Client;
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Publish feed to pubsubhubbub.appspot.com.
@@ -20,14 +20,14 @@ class Publisher
     /**
      * Create a new publisher.
      *
-     * @param string         $hub            A hub (url) to ping
-     * @param Router         $router         Symfony Router to generate the feed xml
-     * @param Client         $client         Guzzle client to send the request
-     * @param UserRepository $userRepository
-     * @param string         $host           Host of the project (used to generate route from a command)
-     * @param string         $scheme         Scheme of the project (used to generate route from a command)
+     * @param string          $hub            A hub (url) to ping
+     * @param RouterInterface $router         Symfony Router to generate the feed xml
+     * @param Client          $client         Guzzle client to send the request
+     * @param UserRepository  $userRepository
+     * @param string          $host           Host of the project (used to generate route from a command)
+     * @param string          $scheme         Scheme of the project (used to generate route from a command)
      */
-    public function __construct($hub, Router $router, Client $client, UserRepository $userRepository, $host, $scheme)
+    public function __construct($hub, RouterInterface $router, Client $client, UserRepository $userRepository, $host, $scheme)
     {
         $this->hub = $hub;
         $this->router = $router;

--- a/tests/AppBundle/Consumer/SyncStarredReposTest.php
+++ b/tests/AppBundle/Consumer/SyncStarredReposTest.php
@@ -401,7 +401,7 @@ class SyncStarredReposTest extends WebTestCase
             $userRepository,
             $starRepository,
             $repoRepository,
-            false, // simulate a bad client
+            null, // simulate a bad client
             $logger
         );
 

--- a/tests/AppBundle/Consumer/SyncVersionsTest.php
+++ b/tests/AppBundle/Consumer/SyncVersionsTest.php
@@ -974,7 +974,7 @@ class SyncVersionsTest extends WebTestCase
             $repoRepository,
             $versionRepository,
             $pubsubhubbub,
-            false, // simulate a bad client
+            null, // simulate a bad client
             $logger
         );
 

--- a/tests/AppBundle/Github/ClientDiscoveryTest.php
+++ b/tests/AppBundle/Github/ClientDiscoveryTest.php
@@ -173,7 +173,7 @@ class ClientDiscoveryTest extends WebTestCase
 
         $records = $logHandler->getRecords();
 
-        $this->assertFalse($resClient);
+        $this->assertNull($resClient);
 
         $this->assertSame('No way to authenticate a client with enough rate limit remaining :(', $records[0]['message']);
     }


### PR DESCRIPTION
- Consumer, GitHub, PubSubHubbub & Webfeeds are now autowire too
- ClientDiscovery now return `null` when no client are found. It’s then easier to autowire GitHub client in consumers because we can type client (to GitHub\Client) and use null when no client are found by the ClientDiscovery

Also fix env definition in command