### PR TITLE
Update the way to auth on GitHub

### DIFF
--- a/src/AppBundle/Github/ClientDiscovery.php
+++ b/src/AppBundle/Github/ClientDiscovery.php
@@ -70,7 +70,7 @@ class ClientDiscovery
         );
 
         // try with the application default client
-        $this->client->authenticate($this->clientId, $this->clientSecret, GithubClient::AUTH_URL_CLIENT_ID);
+        $this->client->authenticate($this->clientId, $this->clientSecret, GithubClient::AUTH_HTTP_PASSWORD);
 
         $remaining = $this->getRateLimits($this->client, $this->logger);
         if ($remaining >= self::THRESHOLD_RATE_REMAIN_APP) {


### PR DESCRIPTION
Because it's deprecated now.
See https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters