### PR TITLE
Exclude 404 from log / Sentry

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -7,6 +7,8 @@ monolog:
             type: fingers_crossed
             action_level: error
             handler: streamed_main
+            excluded_404s:
+                - .*
         streamed_main:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
@@ -17,6 +19,9 @@ monolog:
 
 sentry:
     dsn: "%sentry_dsn%"
+    options:
+        excluded_exceptions:
+            - Symfony\Component\HttpKernel\Exception\NotFoundHttpException
 
 snc_redis:
     doctrine:


### PR DESCRIPTION
We don't care about them, at least, in production.