### PR TITLE
Improve HTTP Cache for GitHub API calls

### DIFF
--- a/src/AppBundle/Cache/CustomRedisCachePool.php
+++ b/src/AppBundle/Cache/CustomRedisCachePool.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace AppBundle\Cache;
+
+use Cache\Adapter\Common\PhpCacheItem;
+use Cache\Adapter\Predis\PredisCachePool;
+
+/**
+ * Store lightweight response from GitHub to avoid having a huge Redis database.
+ * Stored response will only have what Bandito.re needs. We should use GraphQL to only request fields we want
+ * but rate limit is still too low for the app.
+ *
+ * Affected url from the GitHub API:
+ *     - starred
+ *     - git/refs/tags
+ *     - tag
+ *     - release
+ *
+ * All other response are usually for a version and we don't need to store them. They won't be cached.
+ */
+class CustomRedisCachePool extends PredisCachePool
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function storeItemInCache(PhpCacheItem $item, $ttl)
+    {
+        if ($ttl < 0) {
+            return false;
+        }
+
+        $currentItem = $item->get();
+
+        if (404 === $currentItem['response']->getStatusCode() || 451 === $currentItem['response']->getStatusCode()) {
+            return parent::storeItemInCache($item, $ttl);
+        }
+
+        $body = json_decode($currentItem['body'], true);
+        // we don't need to reduce empty array ^^
+        if (empty($body)) {
+            return parent::storeItemInCache($item, $ttl);
+        }
+
+        // do not cache version (ie: release or tag) information
+        // we don't query them later because the version will be saved and never updated
+        if (isset($body['committer']) || isset($body['tagger']) || isset($body['prerelease'])) {
+            return true;
+        }
+
+        if (isset($body[0]['ref']) && false !== strpos($body[0]['ref'], 'refs/tags/')) {
+            // response for git/refs/tags
+            foreach ($body as $key => $element) {
+                $body[$key] = [
+                    'ref' => $element['ref'],
+                    'object' => [
+                        'sha' => $element['object']['sha'],
+                        'type' => $element['object']['type'],
+                    ],
+                ];
+            }
+        } elseif (isset($body[0]['zipball_url'])) {
+            // response for only one tag
+            $body = [
+                0 => [
+                    'name' => $body[0]['name'],
+                ],
+            ];
+        } elseif (isset($body[0]['full_name'])) {
+            // response for starred repos
+            foreach ($body as $key => $element) {
+                $body[$key] = [
+                    'id' => $element['id'],
+                    'name' => $element['name'],
+                    'homepage' => $element['homepage'],
+                    'language' => $element['language'],
+                    'full_name' => $element['full_name'],
+                    'description' => $element['description'],
+                    'owner' => [
+                        'avatar_url' => $element['owner']['avatar_url'],
+                    ],
+                ];
+            }
+        } else {
+            $this->log('warning', 'Unmatched response from custom Redis cache', ['body' => $body]);
+        }
+
+        $currentItem['body'] = json_encode($body);
+
+        $item->set($currentItem);
+
+        return parent::storeItemInCache($item, $ttl);
+    }
+}

--- a/src/AppBundle/Github/ClientDiscovery.php
+++ b/src/AppBundle/Github/ClientDiscovery.php
@@ -2,8 +2,8 @@
 
 namespace AppBundle\Github;
 
+use AppBundle\Cache\CustomRedisCachePool;
 use AppBundle\Repository\UserRepository;
-use Cache\Adapter\Predis\PredisCachePool;
 use Github\Client as GithubClient;
 use Predis\Client as RedisClient;
 use Psr\Log\LoggerInterface;
@@ -60,7 +60,7 @@ class ClientDiscovery
     {
         // attache the cache in anycase
         $this->client->addCache(
-            new PredisCachePool($this->redis),
+            new CustomRedisCachePool($this->redis),
             [
                 // the default config include "private" to avoid caching request with this header
                 // since we can use a user token, Github will return a "private" but we want to cache that request

--- a/tests/AppBundle/Cache/CustomRedisCachePoolTest.php
+++ b/tests/AppBundle/Cache/CustomRedisCachePoolTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\AppBundle\Consumer;
+
+use AppBundle\Cache\CustomRedisCachePool;
+use Cache\Adapter\Common\CacheItem;
+use GuzzleHttp\Psr7\Response;
+use Predis\Response\Status;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class CustomRedisCachePoolTest extends WebTestCase
+{
+    public function testResponseWithEmptyBody()
+    {
+        $redisStatus = new Status('OK');
+        $cache = $this->getMockBuilder('Predis\ClientInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cache->expects($this->once())
+            ->method('__call')
+            ->willReturn($redisStatus);
+
+        $body = json_encode([]);
+
+        $response = new Response(
+            200,
+            [],
+            $body
+        );
+        $item = new CacheItem('superkey', true, [
+            'response' => $response,
+            'body' => $body,
+        ]);
+
+        $cachePool = new CustomRedisCachePool($cache);
+        $cachePool->save($item);
+    }
+
+    public function testResponseWith404()
+    {
+        $redisStatus = new Status('OK');
+        $cache = $this->getMockBuilder('Predis\ClientInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cache->expects($this->once())
+            ->method('__call')
+            ->willReturn($redisStatus);
+
+        $response = new Response(404);
+        $item = new CacheItem('superkey', true, [
+            'response' => $response,
+            'body' => '',
+        ]);
+
+        $cachePool = new CustomRedisCachePool($cache);
+        $cachePool->save($item);
+    }
+
+    public function testResponseWithRelease()
+    {
+        $cache = $this->getMockBuilder('Predis\ClientInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cache->expects($this->never())
+            ->method('__call');
+
+        $body = json_encode([
+            'tag_name' => 'V1.1.0',
+            'name' => 'V1.1.0',
+            'prerelease' => false,
+            'published_at' => '2014-12-01T18:28:39Z',
+            'body' => 'This is the first release after our major push.',
+        ]);
+
+        $response = new Response(
+            200,
+            [],
+            $body
+        );
+        $item = new CacheItem('superkey', true, [
+            'response' => $response,
+            'body' => $body,
+        ]);
+
+        $cachePool = new CustomRedisCachePool($cache);
+        $cachePool->save($item);
+    }
+
+    public function testResponseWithRefTags()
+    {
+        $redisStatus = new Status('OK');
+        $cache = $this->getMockBuilder('Predis\ClientInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cache->expects($this->once())
+            ->method('__call')
+            ->willReturn($redisStatus);
+
+        $body = json_encode([[
+                'ref' => 'refs/tags/1.0.0',
+                'url' => 'https://api.github.com/repos/snc/SncRedisBundle/git/refs/tags/1.0.0',
+                'object' => [
+                    'sha' => '04b99722e0c25bfc45926cd3a1081c04a8e950ed',
+                    'type' => 'commit',
+                    'url' => 'https://api.github.com/repos/snc/SncRedisBundle/git/commits/04b99722e0c25bfc45926cd3a1081c04a8e950ed',
+                ],
+            ],
+            [
+                'ref' => 'refs/tags/1.0.1',
+                'url' => 'https://api.github.com/repos/snc/SncRedisBundle/git/refs/tags/1.0.1',
+                'object' => [
+                    'sha' => '4845571072d49c2794b165482420b66c206a942a',
+                    'type' => 'commit',
+                    'url' => 'https://api.github.com/repos/snc/SncRedisBundle/git/commits/4845571072d49c2794b165482420b66c206a942a',
+                ],
+            ],
+        ]);
+
+        $response = new Response(
+            200,
+            [],
+            $body
+        );
+        $item = new CacheItem('superkey', true, [
+            'response' => $response,
+            'body' => $body,
+        ]);
+
+        $cachePool = new CustomRedisCachePool($cache);
+        $cachePool->save($item);
+    }
+
+    public function testResponseWithTag()
+    {
+        $redisStatus = new Status('OK');
+        $cache = $this->getMockBuilder('Predis\ClientInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cache->expects($this->once())
+            ->method('__call')
+            ->willReturn($redisStatus);
+
+        $body = json_encode([[
+            'name' => '2.0.1',
+            'zipball_url' => 'https://api.github.com/repos/snc/SncRedisBundle/zipball/2.0.1',
+            'tarball_url' => 'https://api.github.com/repos/snc/SncRedisBundle/tarball/2.0.1',
+            'commit' => [
+                'sha' => '02c808d157c79ac32777e19f3ec31af24a32d2df',
+                'url' => 'https://api.github.com/repos/snc/SncRedisBundle/commits/02c808d157c79ac32777e19f3ec31af24a32d2df',
+            ],
+        ]]);
+
+        $response = new Response(
+            200,
+            [],
+            $body
+        );
+        $item = new CacheItem('superkey', true, [
+            'response' => $response,
+            'body' => $body,
+        ]);
+
+        $cachePool = new CustomRedisCachePool($cache);
+        $cachePool->save($item);
+    }
+
+    public function testResponseWithStarredRepos()
+    {
+        $redisStatus = new Status('OK');
+        $cache = $this->getMockBuilder('Predis\ClientInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $cache->expects($this->once())
+            ->method('__call')
+            ->willReturn($redisStatus);
+
+        $body = json_encode([[
+            'description' => 'banditore',
+            'homepage' => 'http://banditore.io',
+            'language' => 'PHP',
+            'name' => 'banditore',
+            'full_name' => 'j0k3r/banditore',
+            'id' => 666,
+            'owner' => [
+                'avatar_url' => 'http://avatar.api/banditore.jpg',
+            ],
+        ]]);
+
+        $response = new Response(
+            200,
+            [],
+            $body
+        );
+        $item = new CacheItem('superkey', true, [
+            'response' => $response,
+            'body' => $body,
+        ]);
+
+        $cachePool = new CustomRedisCachePool($cache);
+        $cachePool->save($item);
+    }
+}


### PR DESCRIPTION
Instead of storing the whole huge response from GitHub API, we only keep information we need.
It's 10x smaller for some calls.
It'll avoid having a huge Redis database.

Also, don't cache version/release/tag information as we won't query them again in the future. Once the version is saved we don't update it.