### PR TITLE
Re-enable lazy service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "laminas/laminas-code": "^3.4",
         "league/oauth2-github": "^2.0",
         "marcw/rss-writer": "^0.4",
-        "ocramius/proxy-manager": "^2.1",
         "odolbeau/rabbit-mq-admin-toolkit": "^5.0",
         "php-amqplib/php-amqplib": "^2.6",
         "php-http/guzzle6-adapter": "^2.0",
@@ -42,6 +41,7 @@
         "symfony/monolog-bundle": "^3.5",
         "symfony/orm-pack": "^1.0",
         "symfony/polyfill-apcu": "^1.0",
+        "symfony/proxy-manager-bridge": "^5.0",
         "symfony/security-bundle": "^5.0",
         "symfony/translation": "^5.0",
         "symfony/twig-pack": "^1.0",
@@ -100,7 +100,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": true,
-            "require": "5.0.*"
+            "require": "^5.0"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5b0dcc01ba3645d228ab5691ec50fea",
+    "content-hash": "3b93bb4c6f14c8d5fc4908cf2137b87c",
     "packages": [
         {
             "name": "ashleydawson/simple-pagination",
@@ -7316,6 +7316,77 @@
                 }
             ],
             "time": "2020-04-15T15:59:10+00:00"
+        },
+        {
+            "name": "symfony/proxy-manager-bridge",
+            "version": "v5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/proxy-manager-bridge.git",
+                "reference": "5bb3103e5fe510f75779952121a4be434343d83c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/proxy-manager-bridge/zipball/5bb3103e5fe510f75779952121a4be434343d83c",
+                "reference": "5bb3103e5fe510f75779952121a4be434343d83c",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/proxy-manager": "~2.1",
+                "php": "^7.2.5",
+                "symfony/dependency-injection": "^5.0"
+            },
+            "conflict": {
+                "zendframework/zend-eventmanager": "2.6.0"
+            },
+            "require-dev": {
+                "symfony/config": "^4.4|^5.0"
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\ProxyManager\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ProxyManager Bridge",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-27T16:56:45+00:00"
         },
         {
             "name": "symfony/routing",


### PR DESCRIPTION
Lazy service aren't built-in Symfony like it was on 3.4.
It needs the `symfony/proxy-manager-bridge` (instead of `ocramius/proxy-manager`)