### PR TITLE
Ensure message is a string

### DIFF
--- a/src/MessageHandler/VersionsSyncHandler.php
+++ b/src/MessageHandler/VersionsSyncHandler.php
@@ -197,7 +197,7 @@ class VersionsSyncHandler implements MessageHandlerInterface
                         ];
                 }
 
-                $newRelease['message'] = $this->removePgpSignature($newRelease['message']);
+                $newRelease['message'] = $this->removePgpSignature((string) $newRelease['message']);
             }
 
             // render markdown in plain html and use default markdown file if it fails


### PR DESCRIPTION
Because it can sometime be empty or null.