### PR TITLE
Add `user:email` scope

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -47,10 +47,10 @@ when@prod:
                 excluded_http_codes: [404, 405]
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
             nested:
-                type: stream
-                path: php://stderr
+                type: rotating_file
+                path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: debug
-                formatter: monolog.formatter.json
+                max_files: 10
             console:
                 type: console
                 process_psr_3_messages: false
@@ -58,4 +58,4 @@ when@prod:
             deprecation:
                 type: stream
                 channels: [deprecation]
-                path: php://stderr
+                path: "%kernel.logs_dir%/deprecation.log"

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -13,6 +13,7 @@ when@prod:
         handlers:
             sentry:
                 type: service
+                id: Sentry\Monolog\Handler
                 level: !php/const Monolog\Logger::ERROR
                 hub_id: Sentry\State\HubInterface
 

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -134,7 +134,7 @@ class DefaultController extends AbstractController
 
         return $oauth
             ->getClient('github')
-            ->redirect([], []);
+            ->redirect(['user:email'], []);
     }
 
     /**


### PR DESCRIPTION
This allow to retrieve the email from the connected user. Nothing more.

See https://docs.github.com/fr/rest/users/emails?apiVersion=2022-11-28#list-email-addresses-for-the-authenticated-user

Fix #1102

Also:
- add proper file for the logger
- fix Sentry configuration