### PR TITLE
Add ability to ignore a starred repo

### DIFF
--- a/migrations/Version20170222055642.php
+++ b/migrations/Version20170222055642.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -19,7 +20,7 @@ final class Version20170222055642 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on MySQL.');
 
         $repoTable = $schema->getTable('repo');
         $this->skipIf($repoTable->hasColumn('homepage') || $repoTable->hasColumn('language'), 'It seems that you already played this migration.');
@@ -29,7 +30,7 @@ final class Version20170222055642 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on MySQL.');
 
         $this->addSql('ALTER TABLE repo DROP homepage, DROP language');
     }

--- a/migrations/Version20170329095349.php
+++ b/migrations/Version20170329095349.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -19,14 +20,14 @@ final class Version20170329095349 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on MySQL.');
 
         $this->addSql('ALTER TABLE user CHANGE name name VARCHAR(191) DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on MySQL.');
 
         $this->addSql('ALTER TABLE user CHANGE name name VARCHAR(191) NOT NULL COLLATE utf8mb4_unicode_ci');
     }

--- a/migrations/Version20180827105910.php
+++ b/migrations/Version20180827105910.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -19,14 +20,14 @@ final class Version20180827105910 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on MySQL.');
 
         $this->addSql('ALTER TABLE repo ADD removed_at DATETIME DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on MySQL.');
 
         $this->addSql('ALTER TABLE repo DROP removed_at');
     }

--- a/migrations/Version20200511062812.php
+++ b/migrations/Version20200511062812.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
@@ -19,14 +20,14 @@ final class Version20200511062812 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on MySQL.');
 
         $this->addSql('ALTER TABLE user ADD removed_at DATETIME DEFAULT NULL');
     }
 
     public function down(Schema $schema): void
     {
-        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on MySQL.');
 
         $this->addSql('ALTER TABLE user DROP removed_at');
     }

--- a/migrations/Version20260408120000.php
+++ b/migrations/Version20260408120000.php
@@ -8,29 +8,24 @@ use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Enforce some relations to not be null.
- */
-final class Version20200613153754 extends AbstractMigration
+final class Version20260408120000 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Enforce some relations to not be null';
+        return 'Add per-user repo flag to ignore releases in RSS feeds';
     }
 
     public function up(Schema $schema): void
     {
         $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on MySQL.');
 
-        $this->addSql('ALTER TABLE star CHANGE user_id user_id INT NOT NULL, CHANGE repo_id repo_id INT NOT NULL');
-        $this->addSql('ALTER TABLE version CHANGE repo_id repo_id INT NOT NULL');
+        $this->addSql('ALTER TABLE star ADD ignored_in_feed TINYINT(1) DEFAULT 0 NOT NULL');
     }
 
     public function down(Schema $schema): void
     {
         $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on MySQL.');
 
-        $this->addSql('ALTER TABLE star CHANGE user_id user_id INT DEFAULT NULL, CHANGE repo_id repo_id INT DEFAULT NULL');
-        $this->addSql('ALTER TABLE version CHANGE repo_id repo_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE star DROP ignored_in_feed');
     }
 }

--- a/public/css/banditore.css
+++ b/public/css/banditore.css
@@ -454,6 +454,73 @@ aside.feed b:after {
     background: #ffab80;
 }
 
+.feed-status {
+    display: inline-block;
+    min-width: 5.5em;
+    padding: 0.15em 0.55em;
+    border-radius: 999px;
+    background: #EAF2F5;
+    color: #10556B;
+    font-size: 12px;
+    font-weight: bold;
+    line-height: 1.5;
+    text-align: center;
+}
+
+.feed-status-muted {
+    background: #FFF0E8;
+    color: #AF5D37;
+}
+
+.feed-toggle-form {
+    display: inline;
+    margin-left: 0.45em;
+}
+
+.feed-toggle-button {
+    -webkit-appearance: none;
+    appearance: none;
+    background: none;
+    background-color: transparent;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    color: #10556B;
+    cursor: pointer;
+    display: inline;
+    font: inherit;
+    font-size: 14px;
+    font-weight: 600;
+    line-height: inherit;
+    margin: 0;
+    outline: none;
+    padding: 0;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    vertical-align: baseline;
+}
+
+.feed-toggle-button:hover,
+.feed-toggle-button:focus {
+    color: #2B687F;
+}
+
+.included-indicator {
+    color: #58c026;
+    display: inline-block;
+    font-size: 15px;
+    line-height: 1;
+    vertical-align: middle;
+}
+
+.excluded-indicator {
+    color: #ca3838;
+    display: inline-block;
+    font-size: 15px;
+    line-height: 1;
+    vertical-align: middle;
+}
+
 /* This is the class used for the footer */
 .footer {
     background: #10556B;

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -10,6 +10,7 @@ use App\Repository\StarRepository;
 use App\Repository\UserRepository;
 use App\Repository\VersionRepository;
 use App\Rss\Generator;
+use Doctrine\ORM\EntityManagerInterface;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use MarcW\RssWriter\Bridge\Symfony\HttpFoundation\RssStreamedResponse;
 use MarcW\RssWriter\RssWriter;
@@ -92,6 +93,38 @@ class DefaultController extends AbstractController
         ]);
     }
 
+    #[Route(path: '/dashboard/repositories/{repoId}/feed', name: 'dashboard_repo_feed', methods: ['POST'])]
+    public function updateDashboardRepoFeedAction(int $repoId, Request $request, StarRepository $starRepository, EntityManagerInterface $entityManager): RedirectResponse
+    {
+        if (!$this->security->isGranted('IS_AUTHENTICATED_FULLY')) {
+            return $this->redirect($this->generateUrl('homepage'));
+        }
+
+        /** @var User */
+        $user = $this->getUser();
+        $star = $starRepository->findOneByUserAndRepo($user->getId(), $repoId);
+
+        if (null === $star) {
+            throw $this->createNotFoundException('Repository subscription not found.');
+        }
+
+        $ignoreInFeed = $request->request->getBoolean('ignore_in_feed');
+
+        $star->setIgnoredInFeed($ignoreInFeed);
+        $entityManager->flush();
+
+        $this->addFlash(
+            'info',
+            \sprintf(
+                '%s %s in your RSS feed.',
+                $star->getRepo()->getFullName(),
+                $ignoreInFeed ? 'is now ignored' : 'is now included again'
+            )
+        );
+
+        return $this->redirect($this->generateUrl('dashboard'));
+    }
+
     /**
      * Empty callback action.
      * The request will be handle by the GithubAuthenticator.
@@ -126,7 +159,7 @@ class DefaultController extends AbstractController
     ): RssStreamedResponse {
         $channel = $rssGenerator->generate(
             $user,
-            $this->repoVersion->findForUser($user->getId()),
+            $this->repoVersion->findForFeedUser($user->getId()),
             $this->generateUrl('rss_user', ['uuid' => $user->getUuid()], UrlGeneratorInterface::ABSOLUTE_URL)
         );
 

--- a/src/Entity/Star.php
+++ b/src/Entity/Star.php
@@ -27,6 +27,9 @@ class Star
     #[ORM\Column(name: 'created_at', type: 'datetime', nullable: false)]
     private $createdAt;
 
+    #[ORM\Column(name: 'ignored_in_feed', type: 'boolean', options: ['default' => false])]
+    private bool $ignoredInFeed = false;
+
     public function __construct(#[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'stars')]
         #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false)]
         private readonly User $user, #[ORM\ManyToOne(targetEntity: Repo::class, inversedBy: 'stars')]
@@ -68,5 +71,27 @@ class Star
     public function getCreatedAt()
     {
         return $this->createdAt;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getRepo(): Repo
+    {
+        return $this->repo;
+    }
+
+    public function isIgnoredInFeed(): bool
+    {
+        return $this->ignoredInFeed;
+    }
+
+    public function setIgnoredInFeed(bool $ignoredInFeed): self
+    {
+        $this->ignoredInFeed = $ignoredInFeed;
+
+        return $this;
     }
 }

--- a/src/Repository/StarRepository.php
+++ b/src/Repository/StarRepository.php
@@ -65,4 +65,17 @@ class StarRepository extends ServiceEntityRepository
             ->getQuery()
             ->getSingleScalarResult();
     }
+
+    public function findOneByUserAndRepo(int $userId, int $repoId): ?Star
+    {
+        $stars = $this->createQueryBuilder('s')
+            ->leftJoin('s.repo', 'r')
+            ->where('s.user = :userId')->setParameter('userId', $userId)
+            ->andWhere('r.id = :repoId')->setParameter('repoId', $repoId)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getResult();
+
+        return $stars[0] ?? null;
+    }
 }

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -29,6 +29,7 @@ class UserRepository extends ServiceEntityRepository
             ->select('DISTINCT u.uuid')
             ->leftJoin('u.stars', 's')
             ->where('s.repo IN (:ids)')->setParameter('ids', $repoIds)
+            ->andWhere('s.ignoredInFeed = :ignoredInFeed')->setParameter('ignoredInFeed', false)
             ->getQuery()
             ->getArrayResult();
     }

--- a/src/Repository/VersionRepository.php
+++ b/src/Repository/VersionRepository.php
@@ -53,7 +53,7 @@ class VersionRepository extends ServiceEntityRepository
     public function findForUser($userId, $offset = 0, $length = 20)
     {
         return $this->createQueryBuilder('v')
-            ->select('v.tagName', 'v.name', 'v.createdAt', 'v.body', 'v.prerelease', 'r.fullName', 'r.ownerAvatar', 'r.ownerAvatar', 'r.homepage', 'r.language', 'r.description')
+            ->select('r.id AS repoId', 'v.tagName', 'v.name', 'v.createdAt', 'v.body', 'v.prerelease', 's.ignoredInFeed', 'r.fullName', 'r.ownerAvatar', 'r.ownerAvatar', 'r.homepage', 'r.language', 'r.description')
             ->leftJoin('v.repo', 'r')
             ->leftJoin('r.stars', 's')
             ->where('s.user = :userId')->setParameter('userId', $userId)
@@ -81,6 +81,24 @@ class VersionRepository extends ServiceEntityRepository
             ->where('s.user = :userId')->setParameter('userId', $userId)
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+    /**
+     * Find all versions available in the feed for the given user.
+     */
+    public function findForFeedUser(int $userId, int $offset = 0, int $length = 20): array
+    {
+        return $this->createQueryBuilder('v')
+            ->select('r.id AS repoId', 'v.tagName', 'v.name', 'v.createdAt', 'v.body', 'v.prerelease', 'r.fullName', 'r.ownerAvatar', 'r.ownerAvatar', 'r.homepage', 'r.language', 'r.description')
+            ->leftJoin('v.repo', 'r')
+            ->leftJoin('r.stars', 's')
+            ->where('s.user = :userId')->setParameter('userId', $userId)
+            ->andWhere('s.ignoredInFeed = :ignoredInFeed')->setParameter('ignoredInFeed', false)
+            ->orderBy('v.createdAt', 'desc')
+            ->setFirstResult($offset)
+            ->setMaxResults($length)
+            ->getQuery()
+            ->getArrayResult();
     }
 
     /**

--- a/templates/default/_line_version.html.twig
+++ b/templates/default/_line_version.html.twig
@@ -13,8 +13,29 @@
         {% if repo.prerelease -%}
             <span class="label_prerelease">pre-release</span>
         {% endif -%}
+
     </td>
     <td data-th="Date">
         <time datetime="{{ repo.createdAt|date("c") }}" title="{{ repo.createdAt|date("c") }}">{{ repo.createdAt|time_diff }}</time>
     </td>
+    {% if repo.repoId is defined -%}
+        <td data-th="Included">
+            {% if repo.ignoredInFeed|default(false) -%}
+                <span class="excluded-indicator" title="Excluded from RSS">
+                    <i class="fa fa-times" aria-hidden="true"></i>
+                </span>
+            {% else -%}
+                <span class="included-indicator" title="Included in RSS">
+                    <i class="fa fa-check" aria-hidden="true"></i>
+                </span>
+            {% endif -%}
+
+            <form action="{{ path('dashboard_repo_feed', { repoId: repo.repoId }) }}" method="post" class="feed-toggle-form">
+                <input type="hidden" name="ignore_in_feed" value="{{ repo.ignoredInFeed|default(false) ? '0' : '1' }}"/>
+                <button type="submit" class="feed-toggle-button">
+                    {{ repo.ignoredInFeed|default(false) ? 'Include again' : 'Exclude' }}
+                </button>
+            </form>
+        </td>
+    {% endif -%}
 </tr>

--- a/templates/default/dashboard.html.twig
+++ b/templates/default/dashboard.html.twig
@@ -18,6 +18,7 @@
 
         <aside class="feed pure-u-lg-3-5 pure-u-md-4-5 pure-u-sm-5-5">
             <p>You can grab your <b><a href="{{ url('rss_user', { uuid: app.user.uuid }) }}">feed link</a></b> and add it to your favorite feed reader. Every new release will show up in it.</p>
+            <p>If one repository is too noisy, you can ignore it from the RSS feed without unstarring it on GitHub.</p>
         </aside>
 
         <h2 class="content-head is-center">Your latest releases</h2>
@@ -43,6 +44,7 @@
                     <th>Repository</th>
                     <th>Last&nbsp;version</th>
                     <th>Published&nbsp;at</th>
+                    <th>Included in feed</th>
                 </tr>
             </thead>
 
@@ -57,6 +59,12 @@
                         </td>
                         <td data-th="Last">First release (<a href="#">v1.0.0</a>)</td>
                         <td data-th="Date"><time datetime="{{ app.user.createdAt|date("c") }}" title="{{ app.user.createdAt|date("c") }}">{{ app.user.createdAt|time_diff }}</time></td>
+                        <td data-th="Included">
+                            <span class="included-indicator" title="Included in RSS">
+                                <i class="fa fa-check" aria-hidden="true"></i>
+                            </span>
+                            <button type="button" class="feed-toggle-button">Exclude</button>
+                        </td>
                     </tr>
                     <tr class="pure-table-odd">
                         <td data-th="Repo">
@@ -68,6 +76,12 @@
                             <span class="label_prerelease">pre-release</span>
                         </td>
                         <td data-th="Date"><time datetime="{{ date("-2days")|date("c") }}" title="{{ date("-2days")|date("c") }}">{{ date("-2days")|time_diff }}</time></td>
+                        <td data-th="Included">
+                            <span class="included-indicator" title="Included in RSS">
+                                <i class="fa fa-check" aria-hidden="true"></i>
+                            </span>
+                            <button type="button" class="feed-toggle-button">Exclude</button>
+                        </td>
                     </tr>
                 {% endfor -%}
             </tbody>

--- a/tests/Controller/DefaultControllerTest.php
+++ b/tests/Controller/DefaultControllerTest.php
@@ -3,7 +3,9 @@
 namespace App\Tests\Controller;
 
 use App\Entity\User;
+use App\Repository\StarRepository;
 use App\Repository\UserRepository;
+use Doctrine\DBAL\Connection;
 use MarcW\RssWriter\Bridge\Symfony\HttpFoundation\RssStreamedResponse;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -17,6 +19,7 @@ class DefaultControllerTest extends WebTestCase
     protected function setUp(): void
     {
         $this->client = static::createClient();
+        self::getContainer()->get(Connection::class)->executeStatement('UPDATE star SET ignored_in_feed = 0');
     }
 
     public function testIndexNotLoggedIn(): void
@@ -85,7 +88,29 @@ class DefaultControllerTest extends WebTestCase
 
         $table = $crawler->filter('table')->text();
         $this->assertStringContainsString('test/test', $table, 'Repo test/test exist in a table');
+        $this->assertStringContainsString('Exclude', $table, 'Feed toggle is available from the dashboard');
         $this->assertStringContainsString('ago', $table, 'Date is translated and ok');
+    }
+
+    public function testDashboardRepoFeedToggle(): void
+    {
+        /** @var User */
+        $user = self::getContainer()->get(UserRepository::class)->find(123);
+
+        $this->client->loginUser($user);
+        $this->client->request('POST', '/dashboard/repositories/666/feed', [
+            'ignore_in_feed' => '1',
+        ]);
+
+        $this->assertResponseRedirects('/dashboard', 302);
+
+        $this->client->followRedirect();
+        $this->assertSelectorTextContains('.alert.success', 'test/test is now ignored in your RSS feed.');
+
+        $star = self::getContainer()->get(StarRepository::class)->findOneByUserAndRepo(123, 666);
+
+        $this->assertNotNull($star);
+        $this->assertTrue($star->isIgnoredInFeed());
     }
 
     public function testDashboardPageTooHigh(): void

--- a/tests/Repository/UserRepositoryTest.php
+++ b/tests/Repository/UserRepositoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Repository\UserRepository;
+use Doctrine\DBAL\Connection;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class UserRepositoryTest extends WebTestCase
+{
+    protected function setUp(): void
+    {
+        static::createClient();
+        self::getContainer()->get(Connection::class)->executeStatement('UPDATE star SET ignored_in_feed = 0');
+    }
+
+    public function testFindByRepoIdsExcludesIgnoredStars(): void
+    {
+        $repository = self::getContainer()->get(UserRepository::class);
+
+        $this->assertCount(1, $repository->findByRepoIds([666]));
+
+        self::getContainer()->get(Connection::class)->executeStatement('UPDATE star SET ignored_in_feed = 1 WHERE user_id = 123 AND repo_id = 666');
+
+        $this->assertSame([], $repository->findByRepoIds([666]));
+    }
+}

--- a/tests/Repository/VersionRepositoryTest.php
+++ b/tests/Repository/VersionRepositoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\Repo;
+use App\Entity\Star;
+use App\Entity\User;
+use App\Entity\Version;
+use App\Repository\VersionRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class VersionRepositoryTest extends WebTestCase
+{
+    protected function setUp(): void
+    {
+        static::createClient();
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->createQuery('DELETE FROM App\Entity\Star s WHERE s.user = :userId')
+            ->setParameter('userId', 123)
+            ->execute();
+        $entityManager->createQuery('DELETE FROM App\Entity\Version v WHERE v.repo IN (:repoIds)')
+            ->setParameter('repoIds', [555, 666])
+            ->execute();
+
+        $user = $entityManager->getReference(User::class, 123);
+        $repo666 = $entityManager->getReference(Repo::class, 666);
+        $repo555 = $entityManager->getReference(Repo::class, 555);
+
+        $entityManager->persist(new Star($user, $repo666));
+        $entityManager->persist(new Star($user, $repo555));
+
+        $version666 = new Version($repo666);
+        $version666->hydrateFromGithub([
+            'tag_name' => '1.0.0',
+            'name' => 'First release',
+            'prerelease' => false,
+            'message' => 'YAY',
+            'published_at' => '2019-10-15T07:49:21Z',
+        ]);
+
+        $version555 = new Version($repo555);
+        $version555->hydrateFromGithub([
+            'tag_name' => '1.0.21',
+            'name' => 'First release',
+            'prerelease' => false,
+            'message' => 'YAY 555',
+            'published_at' => '2019-06-15T07:49:21Z',
+        ]);
+
+        $entityManager->persist($version666);
+        $entityManager->persist($version555);
+        $entityManager->flush();
+        $entityManager->clear();
+    }
+
+    public function testFindForFeedUserExcludesIgnoredStars(): void
+    {
+        $repository = self::getContainer()->get(VersionRepository::class);
+
+        self::getContainer()->get(Connection::class)->executeStatement('UPDATE star SET ignored_in_feed = 1 WHERE user_id = 123 AND repo_id = 666');
+
+        $dashboardVersions = $repository->findForUser(123);
+        $feedVersions = $repository->findForFeedUser(123);
+
+        $this->assertNotEmpty($dashboardVersions);
+        $this->assertTrue($dashboardVersions[0]['ignoredInFeed']);
+        $this->assertCount(1, $feedVersions);
+        $this->assertSame('symfony/symfony', $feedVersions[0]['fullName']);
+    }
+}


### PR DESCRIPTION
If the repository is ignored, new releases will appear only in the dashboard rather than the feed. From the dashboard, you'll be able to exclude/include the repo.

<img width="2094" height="1412" alt="Image" src="https://github.com/user-attachments/assets/7c4f6f1f-1278-4b12-981f-4a15a9e492c9" />

Also fix the `->getName()` from the migration, which doesn't exist anymore

Fix https://github.com/j0k3r/banditore/issues/1466